### PR TITLE
[REFACTOR] 기존 화면 Scaffold → BaseScaffold 전환 #17

### DIFF
--- a/lib/core/ui/base/base_scaffold.dart
+++ b/lib/core/ui/base/base_scaffold.dart
@@ -25,7 +25,7 @@ class BaseScaffold extends StatelessWidget {
     return Scaffold(
       backgroundColor: backgroundColor,
       appBar: appBar,
-      body: body,
+      body: SafeArea(child: body),
       bottomNavigationBar: bottomNavigationBar,
       floatingActionButton: floatingActionButton,
       resizeToAvoidBottomInset: resizeToAvoidBottomInset,

--- a/lib/core/ui/base/base_scaffold.dart
+++ b/lib/core/ui/base/base_scaffold.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import '../../design_system/app_colors.dart';
+
+class BaseScaffold extends StatelessWidget {
+  final Widget body;
+  final Color backgroundColor;
+  final PreferredSizeWidget? appBar;
+  final Widget? bottomNavigationBar;
+  final Widget? floatingActionButton;
+  final bool resizeToAvoidBottomInset;
+
+  const BaseScaffold({
+    super.key,
+    required this.body,
+    this.backgroundColor = AppColors.white,
+    this.appBar,
+    this.bottomNavigationBar,
+    this.floatingActionButton,
+    this.resizeToAvoidBottomInset = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: backgroundColor,
+      appBar: appBar,
+      body: body,
+      bottomNavigationBar: bottomNavigationBar,
+      floatingActionButton: floatingActionButton,
+      resizeToAvoidBottomInset: resizeToAvoidBottomInset,
+    );
+  }
+}

--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:ondo/core/ui/base/base_scaffold.dart';
 import 'package:ondo/presentation/home/widgets/home_top_bar.dart';
-
-
 
 void main() {
   runApp(
     MaterialApp(
       home: HomeScreen(),
-    )
+    ),
   );
 }
 
@@ -18,15 +17,12 @@ class HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return SafeArea(
       top: true,
-      child: Scaffold(
-        backgroundColor: Colors.white,
+      child: BaseScaffold(
         body: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: Column(
             children: [
               HomeTopBar(),
-
-
             ],
           ),
         ),


### PR DESCRIPTION
## 📌 개요

> 앱 전반에서 공통으로 사용할 Scaffold 구조를 BaseScaffold로 분리하여
> 화면 간 중복 코드를 줄이고 공통 UX 정책을 한 곳에서 관리할 수 있도록 합니다.

---

## 🧩 작업 내용

- [x] 공통 Scaffold 래퍼인 BaseScaffold 위젯 추가
- [x] 디자인 시스템 기반 기본 배경색 적용
- [x] appBar, bottomNavigationBar, floatingActionButton, resizeToAvoidBottomInset 옵션 공통화

---

## 📎 참고 사항

- 디자인 시스템(AppColors)
- 추후 화면 리팩토링을 위한 베이스 구조 추가
