### PR TITLE
[FEATURE] 회원가입 닉네임 설정 및 유효성 검사

### DIFF
--- a/lib/core/design_system/app_layout.dart
+++ b/lib/core/design_system/app_layout.dart
@@ -12,6 +12,7 @@ class AppSpacing {
   static const double s16 = 16;
   static const double s24 = 24;
   static const double s36 = 36;
+  static const double s76 = 76;
 }
 
 class AppGap {
@@ -32,6 +33,7 @@ class AppGap {
   static const SizedBox v16 = SizedBox(height: AppSpacing.s16);
   static const SizedBox v24 = SizedBox(height: AppSpacing.s24);
   static const SizedBox v36 = SizedBox(height: AppSpacing.s36);
+  static const SizedBox v76 = SizedBox(height: AppSpacing.s76);
 }
 
 class AppPadding {

--- a/lib/core/design_system/app_strings.dart
+++ b/lib/core/design_system/app_strings.dart
@@ -48,7 +48,7 @@ class AppStrings {
 
   static const alreadyRegisteredMickName = '이미 등록된 닉네임이에요!';
 
-  static const nicknameImmutableWarning = '한번 선택한 닉네임은 변경할 수 없어요! 신중히 선택해주세요!';
+  static const nicknameImmutableWarning = '*한번 선택한 닉네임은 변경할 수 없어요! \n  신중히 선택해주세요!';
 
   static const signupCompletionTitle = '회원가입이 완료되었어요! \n본격적으로 시작하기 전에..';
 

--- a/lib/presentation/auth/signup/controllers/nickname_input_controller.dart
+++ b/lib/presentation/auth/signup/controllers/nickname_input_controller.dart
@@ -1,0 +1,61 @@
+import 'dart:developer';
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:get/get_state_manager/src/simple/get_controllers.dart';
+import 'package:ondo/core/design_system/app_strings.dart';
+
+enum NicknameInputState {
+  initial,
+  valid,
+  invalid,
+}
+
+class NicknameInputController extends GetxController {
+  final TextEditingController nicknameController = TextEditingController();
+
+  NicknameInputState state = NicknameInputState.initial;
+
+  bool get hasInput => nicknameController.text.trim().isNotEmpty;
+
+  bool get conSubmit => hasInput;
+
+  @override
+  void onInit() {
+    super.onInit();
+
+    nicknameController.addListener(
+      () {
+        update();
+      },
+    );
+  }
+
+  void validateNickname(){
+    final nickname = nicknameController.text.trim();
+
+    if(nickname == 'test1')
+    {
+      state = NicknameInputState.invalid;
+      update();
+      return;
+    }
+
+    state = NicknameInputState.valid;
+    update();
+    log('닉네임 설정');
+  }
+
+  String? get errorText {
+    if(state == NicknameInputState.invalid){
+      return AppStrings.alreadyRegisteredMickName;
+    }
+    return null;
+  }
+
+  @override
+  void onClose() {
+    nicknameController.dispose();
+    super.onClose();
+  }
+}

--- a/lib/presentation/auth/signup/screens/nickname_setup_screen.dart
+++ b/lib/presentation/auth/signup/screens/nickname_setup_screen.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:ondo/core/design_system/app_colors.dart';
+import 'package:ondo/core/design_system/app_layout.dart';
+import 'package:ondo/core/design_system/app_strings.dart';
+import 'package:ondo/core/design_system/app_text_styles.dart';
+import 'package:ondo/core/design_system/component_variants.dart';
+import '../../../../core/design_system/components/custom_button.dart';
+import 'package:ondo/core/design_system/components/custom_textfield.dart';
+import 'package:ondo/core/ui/base/base_scaffold.dart';
+
+void main() {
+  runApp(
+    MaterialApp(
+      home: NicknameSetupScreen(),
+    ),
+  );
+}
+
+class NicknameSetupScreen extends StatefulWidget {
+  const NicknameSetupScreen({super.key});
+
+  @override
+  State<NicknameSetupScreen> createState() => _NicknameSetupScreenState();
+}
+
+TextEditingController controller = TextEditingController();
+
+class _NicknameSetupScreenState extends State<NicknameSetupScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: BaseScaffold(
+        body: Padding(
+          padding: AppPadding.screenHorizontal,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  AppGap.v76,
+                  Text(
+                    AppStrings.nicknameInputTitle,
+                    style: AppTextStyles.titleSm(),
+                  ),
+                  AppGap.v8,
+                  Text(
+                    AppStrings.nicknameImmutableWarning,
+                    style: AppTextStyles.caption(textColor: AppColors.gray70),
+                  ),
+                  AppGap.v24,
+                  LabelTextField(
+                    label: '닉네임',
+                    controller: controller,
+                    hintText: '닉네임을 입력해주세요',
+                  ),
+                ],
+              ),
+              Column(
+                children: [
+                  CustomButton(
+                    text: '닉네임 확정',
+                    variant: ButtonVariant.primary,
+                  ),
+                  AppGap.v16,
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/auth/signup/screens/nickname_setup_screen.dart
+++ b/lib/presentation/auth/signup/screens/nickname_setup_screen.dart
@@ -1,20 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:get/get_core/src/get_main.dart';
+import 'package:get/get_instance/src/extension_instance.dart';
+import 'package:get/get_navigation/src/root/get_material_app.dart';
+import 'package:get/get_state_manager/src/simple/get_state.dart';
 import 'package:ondo/core/design_system/app_colors.dart';
 import 'package:ondo/core/design_system/app_layout.dart';
 import 'package:ondo/core/design_system/app_strings.dart';
 import 'package:ondo/core/design_system/app_text_styles.dart';
 import 'package:ondo/core/design_system/component_variants.dart';
+import 'package:ondo/presentation/auth/signup/controllers/nickname_input_controller.dart';
 import '../../../../core/design_system/components/custom_button.dart';
 import 'package:ondo/core/design_system/components/custom_textfield.dart';
 import 'package:ondo/core/ui/base/base_scaffold.dart';
 
 void main() {
+  Get.put(NicknameInputController());
+
   runApp(
-    MaterialApp(
+    GetMaterialApp(
       home: NicknameSetupScreen(),
     ),
   );
 }
+
 
 class NicknameSetupScreen extends StatefulWidget {
   const NicknameSetupScreen({super.key});
@@ -35,40 +43,62 @@ class _NicknameSetupScreenState extends State<NicknameSetupScreen> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  AppGap.v76,
-                  Text(
-                    AppStrings.nicknameInputTitle,
-                    style: AppTextStyles.titleSm(),
-                  ),
-                  AppGap.v8,
-                  Text(
-                    AppStrings.nicknameImmutableWarning,
-                    style: AppTextStyles.caption(textColor: AppColors.gray70),
-                  ),
-                  AppGap.v24,
-                  LabelTextField(
-                    label: '닉네임',
-                    controller: controller,
-                    hintText: '닉네임을 입력해주세요',
-                  ),
-                ],
-              ),
-              Column(
-                children: [
-                  CustomButton(
-                    text: '닉네임 확정',
-                    variant: ButtonVariant.primary,
-                  ),
-                  AppGap.v16,
-                ],
-              ),
+              _buildForm(),
+              _buildSubmitButton(),
             ],
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildForm() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        AppGap.v76,
+        Text(
+          AppStrings.nicknameInputTitle,
+          style: AppTextStyles.titleSm(),
+        ),
+        AppGap.v8,
+        Text(
+          AppStrings.nicknameImmutableWarning,
+          style: AppTextStyles.caption(textColor: AppColors.gray70),
+        ),
+        AppGap.v24,
+
+        GetBuilder<NicknameInputController>(
+          builder: (controller) {
+            return LabelTextField(
+              label: '닉네임',
+              controller: controller.nicknameController,
+              hintText: '닉네임을 입력해주세요',
+              errorText: controller.errorText,
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSubmitButton() {
+    return GetBuilder<NicknameInputController>(
+      builder: (controller) {
+        return Column(
+          children: [
+            CustomButton(
+              text: '닉네임 확정',
+              variant: ButtonVariant.primary,
+              enabled: controller.conSubmit,
+              onPressed: controller.conSubmit
+                  ? controller.validateNickname
+                  : null,
+            ),
+            AppGap.v16,
+          ],
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## 📌 작업 개요

회원가입 과정에서 사용자가 닉네임을 입력하고,
입력 여부 및 중복 여부에 따라 유효성 검사를 수행하는 기능을 구현했습니다.

닉네임 설정 화면 UI 퍼블리싱 이후,
상태 관리 및 버튼 제어 로직을 추가하여 실제 동작 가능한 기능으로 완성했습니다.

---

## 🧩 작업 내용

* 닉네임 입력 화면 UI 구성
* 닉네임 입력 여부에 따른 버튼 활성 / 비활성 처리
* 데모 데이터(`test1`) 기반 닉네임 중복 유효성 검사 로직 구현
* 유효성 실패 시 에러 메시지 노출 및 에러 컬러 적용
* GetX Controller 기반 상태 관리 구조 적용

---

## ✅ 동작 방식

* 닉네임 입력 시 버튼 활성화
* 버튼 비활성 상태에서는 클릭 불가
* 버튼 활성 상태에서 클릭 시 닉네임 유효성 검사 수행
* 유효성 통과 시 로그 출력 (`닉네임 설정`)
* 유효성 실패 시 `"이미 등록된 닉네임이에요!"` 에러 메시지 표시

---

## 📎 참고 사항

* 중복 확인 API 연동은 추후 이슈로 분리 예정
* CustomButton의 `enabled` 정책에 따라 버튼 상태 제어
* go_router + GetX 구조를 고려한 Stateless + GetView 패턴 사용

---

close #44 
