### PR TITLE
[FEATURE] 회원가입 프로필 이미지 설정 기능 구현

### DIFF
--- a/lib/core/design_system/app_layout.dart
+++ b/lib/core/design_system/app_layout.dart
@@ -2,6 +2,7 @@ import 'dart:core';
 import 'package:flutter/material.dart';
 
 class AppSpacing {
+  static const double s2 = 2;
   static const double s4 = 4;
   static const double s6 = 6;
   static const double s8 = 8;
@@ -10,8 +11,11 @@ class AppSpacing {
   static const double s12 = 12;
   static const double s14 = 14;
   static const double s16 = 16;
+  static const double s18 = 18;
   static const double s24 = 24;
   static const double s36 = 36;
+  static const double s40 = 40;
+  static const double s76 = 76;
 }
 
 class AppGap {
@@ -32,6 +36,8 @@ class AppGap {
   static const SizedBox v16 = SizedBox(height: AppSpacing.s16);
   static const SizedBox v24 = SizedBox(height: AppSpacing.s24);
   static const SizedBox v36 = SizedBox(height: AppSpacing.s36);
+  static const SizedBox v40 = SizedBox(height: AppSpacing.s40);
+  static const SizedBox v76 = SizedBox(height: AppSpacing.s76);
 }
 
 class AppPadding {

--- a/lib/presentation/auth/signup/controllers/profile_image_setup_controller.dart
+++ b/lib/presentation/auth/signup/controllers/profile_image_setup_controller.dart
@@ -1,39 +1,40 @@
 import 'dart:developer';
 
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get_state_manager/get_state_manager.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:ondo/core/design_system/app_icon.dart';
 
-class ProfileImageSetupController extends GetxController{
-  late Object profileImage;
+class ProfileImageSetupController extends GetxController {
+  String? profileImagePath;
 
   final ImagePicker _picker = ImagePicker();
+
+  bool get isDefaultProfile => profileImagePath == null;
 
   @override
   void onInit() {
     super.onInit();
-    _setDefaultProfile();
+    resetDefaultProfile();
   }
 
-  void _setDefaultProfile() {
-    profileImage = SvgPicture.asset(AppIcon.defaultProfile.path);
+  void resetDefaultProfile() {
+    profileImagePath = null;
     update();
   }
 
-  Future<void> pickFromGallery() async{
+  Future<void> pickFromGallery() async {
     final XFile? image = await _picker.pickImage(source: ImageSource.gallery);
 
-    if(image != null){
-      profileImage = image;
+    if (image != null) {
+      profileImagePath = image.path;
       update();
     }
   }
 
-  void applyDefaultProfile(){
-    _setDefaultProfile();
-  }
-  void submitProfileImage(){
-    log('프로필 이미지 설정완료: $profileImage');
+  void submitProfileImage() {
+    log(
+      isDefaultProfile
+          ? '프로필 이미지 설정완료: 기본 프로필'
+          : '프로필 이미지 설정완료: $profileImagePath',
+    );
   }
 }

--- a/lib/presentation/auth/signup/controllers/profile_image_setup_controller.dart
+++ b/lib/presentation/auth/signup/controllers/profile_image_setup_controller.dart
@@ -1,0 +1,39 @@
+import 'dart:developer';
+
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:get/get_state_manager/get_state_manager.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:ondo/core/design_system/app_icon.dart';
+
+class ProfileImageSetupController extends GetxController{
+  late Object profileImage;
+
+  final ImagePicker _picker = ImagePicker();
+
+  @override
+  void onInit() {
+    super.onInit();
+    _setDefaultProfile();
+  }
+
+  void _setDefaultProfile() {
+    profileImage = SvgPicture.asset(AppIcon.defaultProfile.path);
+    update();
+  }
+
+  Future<void> pickFromGallery() async{
+    final XFile? image = await _picker.pickImage(source: ImageSource.gallery);
+
+    if(image != null){
+      profileImage = image;
+      update();
+    }
+  }
+
+  void applyDefaultProfile(){
+    _setDefaultProfile();
+  }
+  void submitProfileImage(){
+    log('프로필 이미지 설정완료: $profileImage');
+  }
+}

--- a/lib/presentation/auth/signup/screens/profile_image_setup_screen.dart
+++ b/lib/presentation/auth/signup/screens/profile_image_setup_screen.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:get/get.dart';
 import 'package:ondo/core/design_system/app_colors.dart';
 import 'package:ondo/core/design_system/app_icon.dart';
 import 'package:ondo/core/design_system/app_layout.dart';
@@ -8,16 +11,21 @@ import 'package:ondo/core/design_system/app_text_styles.dart';
 import 'package:ondo/core/design_system/component_variants.dart';
 import 'package:ondo/core/design_system/components/custom_button.dart';
 import 'package:ondo/core/ui/base/base_scaffold.dart';
+import 'package:ondo/presentation/auth/signup/controllers/profile_image_setup_controller.dart';
 
+//테스프용 코드 route 작엽 시 삭제 예정
+//------------------------------------
 void main() {
+  Get.put(ProfileImageSetupController());
   runApp(
     MaterialApp(
       home: ProfileImageSetupScreen(),
     ),
   );
 }
+//------------------------------------
 
-class ProfileImageSetupScreen extends StatelessWidget {
+class ProfileImageSetupScreen extends GetView<ProfileImageSetupController> {
   const ProfileImageSetupScreen({super.key});
 
   @override
@@ -27,66 +35,151 @@ class ProfileImageSetupScreen extends StatelessWidget {
         body: Padding(
           padding: AppPadding.screenHorizontal,
           child: Column(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  AppGap.v76,
-                  Text(
-                    AppStrings.profileRegistrationTitle,
-                    style: AppTextStyles.titleSm(),
-                  ),
-                  Text(
-                    AppStrings.stepSkipHint,
-                    style: AppTextStyles.caption(
-                      textColor: AppColors.gray70,
-                    ),
-                  ),
-                  AppGap.v40,
-                  Align(
-                    alignment: Alignment.center,
-                    child: Stack(
-                      alignment: Alignment.bottomRight,
-                      children: [
-                        Container(
-                          width: 180,
-                          height: 180,
-                          padding: AppPadding.userCard,
-                          child: SvgPicture.asset(AppIcon.defaultProfile.path),
-                        ),
-                        Container(
-                          height: 38,
-                          width: 38,
-                          margin: EdgeInsets.only(
-                            bottom: AppSpacing.s18,
-                            right: AppSpacing.s2,
-                          ),
-                          padding: EdgeInsets.all(7),
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(99),
-                            color: AppColors.primary,
-                          ),
-                          child: SvgPicture.asset(AppIcon.camera.path),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-              Column(
-                children: [
-                  CustomButton(
-                    text: '다음',
-                    variant: ButtonVariant.primary,
-                  ),
-                  AppGap.v16
-                ],
-              ),
+              _buildProfileSection(),
+              _buildNextButton(),
             ],
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildProfileSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        AppGap.v76,
+        Text(
+          AppStrings.profileRegistrationTitle,
+          style: AppTextStyles.titleSm(),
+        ),
+        Text(
+          AppStrings.stepSkipHint,
+          style: AppTextStyles.caption(
+            textColor: AppColors.gray70,
+          ),
+        ),
+        AppGap.v40,
+        _buildProfileImage(),
+      ],
+    );
+  }
+
+  Widget _buildProfileImage() {
+    return Align(
+      alignment: Alignment.center,
+      child: GetBuilder<ProfileImageSetupController>(
+        builder: (controller) {
+          return Stack(
+            alignment: Alignment.bottomRight,
+            children: [
+              _profileImageView(controller),
+              _cameraButtonMenu(controller),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _profileImageView(ProfileImageSetupController controller) {
+    return Container(
+      width: 180,
+      height: 180,
+      padding: AppPadding.userCard,
+      decoration: BoxDecoration(shape: BoxShape.circle),
+      child: controller.isDefaultProfile
+          ? SvgPicture.asset(AppIcon.defaultProfile.path)
+          : ClipOval(
+              child: Image.file(
+                File(controller.profileImagePath!),
+                fit: BoxFit.cover,
+              ),
+            ),
+    );
+  }
+
+  Widget _cameraButtonMenu(ProfileImageSetupController controller) {
+    double popupButtonSize = 135;
+
+    return Container(
+      height: 38,
+      width: 38,
+      margin: EdgeInsets.only(
+        bottom: AppSpacing.s18,
+        right: AppSpacing.s2,
+      ),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(99),
+        color: AppColors.primary,
+      ),
+      child: PopupMenuButton<String>(
+        color: AppColors.white,
+        offset: Offset(-19, 19),
+        constraints: BoxConstraints(
+          maxWidth: popupButtonSize,
+          minWidth: popupButtonSize,
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: AppRadius.baseRadius,
+        ),
+        padding: EdgeInsets.zero,
+        onSelected: (value) {
+          if (value == 'gallery') {
+            controller.pickFromGallery();
+          } else if (value == 'default') {
+            controller.resetDefaultProfile();
+          }
+        },
+        itemBuilder: (context) => [
+          _popupItem(
+            value: 'gallery',
+            text: '앨범에서 사진 선택',
+          ),
+          _popupItem(
+            value: 'default',
+            text: '기본 프로필 적용',
+          ),
+        ],
+        child: Center(
+          child: SvgPicture.asset(AppIcon.camera.path),
+        ),
+      ),
+    );
+  }
+
+  PopupMenuItem<String> _popupItem({
+    required String value,
+    required String text,
+  }) {
+    return PopupMenuItem<String>(
+      value: value,
+      height: 41,
+      child: SizedBox(
+        width: double.infinity,
+        child: Center(
+          child: Text(
+            text,
+            textAlign: TextAlign.start,
+            style: AppTextStyles.caption(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNextButton() {
+    return Column(
+      children: [
+        CustomButton(
+          text: '다음',
+          variant: ButtonVariant.primary,
+          onPressed: controller.submitProfileImage,
+        ),
+        AppGap.v16,
+      ],
     );
   }
 }

--- a/lib/presentation/auth/signup/screens/profile_image_setup_screen.dart
+++ b/lib/presentation/auth/signup/screens/profile_image_setup_screen.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:ondo/core/design_system/app_colors.dart';
+import 'package:ondo/core/design_system/app_icon.dart';
+import 'package:ondo/core/design_system/app_layout.dart';
+import 'package:ondo/core/design_system/app_strings.dart';
+import 'package:ondo/core/design_system/app_text_styles.dart';
+import 'package:ondo/core/design_system/component_variants.dart';
+import 'package:ondo/core/design_system/components/custom_button.dart';
+import 'package:ondo/core/ui/base/base_scaffold.dart';
+
+void main() {
+  runApp(
+    MaterialApp(
+      home: ProfileImageSetupScreen(),
+    ),
+  );
+}
+
+class ProfileImageSetupScreen extends StatelessWidget {
+  const ProfileImageSetupScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: BaseScaffold(
+        body: Padding(
+          padding: AppPadding.screenHorizontal,
+          child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  AppGap.v76,
+                  Text(
+                    AppStrings.profileRegistrationTitle,
+                    style: AppTextStyles.titleSm(),
+                  ),
+                  Text(
+                    AppStrings.stepSkipHint,
+                    style: AppTextStyles.caption(
+                      textColor: AppColors.gray70,
+                    ),
+                  ),
+                  AppGap.v40,
+                  Align(
+                    alignment: Alignment.center,
+                    child: Stack(
+                      alignment: Alignment.bottomRight,
+                      children: [
+                        Container(
+                          width: 180,
+                          height: 180,
+                          padding: AppPadding.userCard,
+                          child: SvgPicture.asset(AppIcon.defaultProfile.path),
+                        ),
+                        Container(
+                          height: 38,
+                          width: 38,
+                          margin: EdgeInsets.only(
+                            bottom: AppSpacing.s18,
+                            right: AppSpacing.s2,
+                          ),
+                          padding: EdgeInsets.all(7),
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(99),
+                            color: AppColors.primary,
+                          ),
+                          child: SvgPicture.asset(AppIcon.camera.path),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              Column(
+                children: [
+                  CustomButton(
+                    text: '다음',
+                    variant: ButtonVariant.primary,
+                  ),
+                  AppGap.v16
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/auth/signup/screens/profile_image_setup_screen.dart
+++ b/lib/presentation/auth/signup/screens/profile_image_setup_screen.dart
@@ -112,7 +112,7 @@ class ProfileImageSetupScreen extends GetView<ProfileImageSetupController> {
         right: AppSpacing.s2,
       ),
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(99),
+        borderRadius: AppRadius.circleRadius,,
         color: AppColors.primary,
       ),
       child: PopupMenuButton<String>(

--- a/lib/presentation/auth/signup/screens/profile_image_setup_screen.dart
+++ b/lib/presentation/auth/signup/screens/profile_image_setup_screen.dart
@@ -112,7 +112,7 @@ class ProfileImageSetupScreen extends GetView<ProfileImageSetupController> {
         right: AppSpacing.s2,
       ),
       decoration: BoxDecoration(
-        borderRadius: AppRadius.circleRadius,,
+        borderRadius: AppRadius.circleRadius,
         color: AppColors.primary,
       ),
       child: PopupMenuButton<String>(


### PR DESCRIPTION
## 📌 작업 개요

회원가입 플로우에서 사용자가 프로필 이미지를 설정할 수 있는 화면을 구현했습니다.
기본 프로필 이미지를 제공하며, 갤러리 선택 또는 기본 프로필 적용이 가능합니다.

---

## 🧩 작업 내용

- 프로필 이미지 설정 화면 UI 퍼블리싱
- 기본 프로필 이미지 상태 처리
- PopupMenuButton 커스텀
  - width 135 / height 82  - 메뉴 텍스트 중앙 정렬
- image_picker를 활용한 갤러리 이미지 선택 기능 구현
- GetX Controller 기반 상태 관리 및 UI 연결
- 버튼 항상 활성화 상태 유지 및 다음 단계 이동 처리

---

## 📎 참고 사항

- Controller는 상태 데이터만 관리하고 UI 표현은 View에서 처리
- GetBuilder 기반 상태 갱신 구조 사용
- go_router Binding 적용 예정 (추후 이슈 분리 가능)

---

close #48 
