### PR TITLE
[FEATURE] 전공 및 관심 분야 선택 기능 구현

### DIFF
--- a/lib/presentation/auth/signup/controllers/major_interest_controller.dart
+++ b/lib/presentation/auth/signup/controllers/major_interest_controller.dart
@@ -2,17 +2,55 @@ import 'dart:developer';
 
 import 'package:get/get.dart';
 
+enum MajorCategory {
+  frontEnd,
+  backEnd,
+  ai,
+  devops,
+  planning,
+  design,
+  android,
+  ios,
+  cloud,
+}
+
+
+extension MajorCategoryX on MajorCategory {
+  String get label {
+    switch (this) {
+      case MajorCategory.frontEnd:
+        return 'FrontEnd';
+      case MajorCategory.backEnd:
+        return 'BackEnd';
+      case MajorCategory.ai:
+        return 'AI';
+      case MajorCategory.devops:
+        return 'DevOps';
+      case MajorCategory.planning:
+        return '기획';
+      case MajorCategory.design:
+        return 'UI/UX';
+      case MajorCategory.android:
+        return 'Android';
+      case MajorCategory.ios:
+        return 'iOS';
+      case MajorCategory.cloud:
+        return 'Cloud';
+    }
+  }
+}
+
 class MajorInterestController extends GetxController{
-  String? selectedMajor;
+  MajorCategory? selectedMajor;
 
-  final Set<String> selectedInterests = {};
+  final Set<MajorCategory> selectedInterests = {};
 
-  void selectMajor(String value){
+  void selectMajor(MajorCategory value){
     selectedMajor = value;
     update();
   }
 
-  void toggleInterest(String value){
+  void toggleInterest(MajorCategory value){
     if(selectedInterests.contains(value)){
       selectedInterests.remove(value);
     }else{
@@ -24,7 +62,7 @@ class MajorInterestController extends GetxController{
   bool get canProceed => selectedMajor != null && selectedInterests.isNotEmpty;
 
   void submit(){
-    log('전공: $selectedMajor');
-    log('관심분야: $selectedInterests');
+    log('전공: ${selectedMajor?.name}');
+    log('관심분야: ${selectedInterests.map((e) => e.name,).toList()}');
   }
 }

--- a/lib/presentation/auth/signup/controllers/major_interest_controller.dart
+++ b/lib/presentation/auth/signup/controllers/major_interest_controller.dart
@@ -1,0 +1,30 @@
+import 'dart:developer';
+
+import 'package:get/get.dart';
+
+class MajorInterestController extends GetxController{
+  String? selectedMajor;
+
+  final Set<String> selectedInterests = {};
+
+  void selectMajor(String value){
+    selectedMajor = value;
+    update();
+  }
+
+  void toggleInterest(String value){
+    if(selectedInterests.contains(value)){
+      selectedInterests.remove(value);
+    }else{
+      selectedInterests.add(value);
+    }
+    update();
+  }
+
+  bool get canProceed => selectedMajor != null && selectedInterests.isNotEmpty;
+
+  void submit(){
+    log('전공: $selectedMajor');
+    log('관심분야: $selectedInterests');
+  }
+}

--- a/lib/presentation/auth/signup/screens/major_interest_setup_screen.dart
+++ b/lib/presentation/auth/signup/screens/major_interest_setup_screen.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:ondo/core/design_system/app_colors.dart';
+import 'package:ondo/core/design_system/app_layout.dart';
+import 'package:ondo/core/design_system/app_strings.dart';
+import 'package:ondo/core/design_system/app_text_styles.dart';
+import 'package:ondo/core/design_system/component_variants.dart';
+import 'package:ondo/core/design_system/components/custom_button.dart';
+import 'package:ondo/core/ui/base/base_scaffold.dart';
+import 'package:ondo/presentation/auth/signup/widgets/title_text.dart';
+
+void main() {
+  runApp(
+    MaterialApp(
+      home: MajorInterestSetupScreen(),
+    ),
+  );
+}
+
+class MajorInterestSetupScreen extends StatelessWidget {
+  const MajorInterestSetupScreen({super.key});
+
+  static const List<String> categories = [
+    'FrontEnd',
+    'BackEnd',
+    'AI',
+    'devops',
+    '기획',
+    'UI/UX',
+    'Android',
+    'ios',
+    'Cloud',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: BaseScaffold(
+        body: Padding(
+          padding: AppPadding.screenHorizontal,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  AppGap.v76,
+                  TitleText.titleText(
+                    AppStrings.majorInterestSelectionTitle,
+                  ),
+                  AppGap.v36,
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '전공',
+                        style: AppTextStyles.textMedium(
+                          textColor: AppColors.gray80,
+                        ),
+                      ),
+                      AppGap.v4,
+                      Wrap(
+                        spacing: AppSpacing.s16,
+                        runSpacing: AppSpacing.s12,
+                        children: categories.map(
+                          (label) {
+                            return SelectableTag(
+                              label: label,
+                              isSelected: true,
+                            );
+                          },
+                        ).toList(),
+                      ),
+                      AppGap.v24,
+                      Text(
+                        '관심분야',
+                        style: AppTextStyles.textMedium(
+                          textColor: AppColors.gray80,
+                        ),
+                      ),
+                      AppGap.v4,
+                      Wrap(
+                        spacing: AppSpacing.s16,
+                        runSpacing: AppSpacing.s12,
+                        children: categories.map(
+                          (label) {
+                            return SelectableTag(
+                              label: label,
+                              isSelected: true,
+                            );
+                          },
+                        ).toList(),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              Column(
+                children: [
+                  CustomButton(
+                    text: '다음',
+                    variant: ButtonVariant.primary,
+                  ),
+                  AppGap.v16,
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class SelectableTag extends StatelessWidget {
+  final String label;
+  final bool isSelected;
+
+  const SelectableTag({
+    super.key,
+    required this.label,
+    required this.isSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: AppPadding.chip,
+      decoration: BoxDecoration(
+        color: isSelected ? AppColors.gray20 : AppColors.primary,
+        borderRadius: AppRadius.baseRadius,
+      ),
+      child: Text(
+        label,
+        style: AppTextStyles.textMedium(
+          textColor: isSelected ? AppColors.black : AppColors.white,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/auth/signup/screens/major_interest_setup_screen.dart
+++ b/lib/presentation/auth/signup/screens/major_interest_setup_screen.dart
@@ -26,20 +26,10 @@ void main() {
 class MajorInterestSetupScreen extends GetView<MajorInterestController> {
   const MajorInterestSetupScreen({super.key});
 
-  static const List<String> categories = [
-    'FrontEnd',
-    'BackEnd',
-    'AI',
-    'devops',
-    '기획',
-    'UI/UX',
-    'Android',
-    'ios',
-    'Cloud',
-  ];
-
   @override
   Widget build(BuildContext context) {
+    final categories = MajorCategory.values;
+
     return SafeArea(
       child: BaseScaffold(
         body: Padding(
@@ -70,7 +60,7 @@ class MajorInterestSetupScreen extends GetView<MajorInterestController> {
   }
 
   Widget _buildInterestSection({
-    required List<String> categories,
+    required List<MajorCategory> categories,
   }) {
     return GetBuilder<MajorInterestController>(
       builder: (controller) {
@@ -88,11 +78,11 @@ class MajorInterestSetupScreen extends GetView<MajorInterestController> {
               spacing: AppSpacing.s16,
               runSpacing: AppSpacing.s12,
               children: categories.map(
-                (label) {
+                (category) {
                   return SelectableTag(
-                    label: label,
-                    isSelected: controller.selectedInterests.contains(label),
-                    onTap: () => controller.toggleInterest(label),
+                    label: category.label,
+                    isSelected: controller.selectedInterests.contains(category),
+                    onTap: () => controller.toggleInterest(category),
                   );
                 },
               ).toList(),
@@ -104,7 +94,7 @@ class MajorInterestSetupScreen extends GetView<MajorInterestController> {
   }
 
   Widget _buildMajorSelectSection({
-    required List<String> categories,
+    required List<MajorCategory> categories,
   }) {
     return GetBuilder<MajorInterestController>(
       builder: (controller) {
@@ -122,11 +112,11 @@ class MajorInterestSetupScreen extends GetView<MajorInterestController> {
               spacing: AppSpacing.s16,
               runSpacing: AppSpacing.s12,
               children: categories.map(
-                (label) {
+                (category) {
                   return SelectableTag(
-                    label: label,
-                    isSelected: controller.selectedMajor == label,
-                    onTap: () => controller.selectMajor(label),
+                    label: category.label,
+                    isSelected: controller.selectedMajor == category,
+                    onTap: () => controller.selectMajor(category),
                   );
                 },
               ).toList(),

--- a/lib/presentation/auth/signup/screens/major_interest_setup_screen.dart
+++ b/lib/presentation/auth/signup/screens/major_interest_setup_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:ondo/core/design_system/app_colors.dart';
 import 'package:ondo/core/design_system/app_layout.dart';
 import 'package:ondo/core/design_system/app_strings.dart';
@@ -6,17 +7,23 @@ import 'package:ondo/core/design_system/app_text_styles.dart';
 import 'package:ondo/core/design_system/component_variants.dart';
 import 'package:ondo/core/design_system/components/custom_button.dart';
 import 'package:ondo/core/ui/base/base_scaffold.dart';
+import 'package:ondo/presentation/auth/signup/controllers/major_interest_controller.dart';
 import 'package:ondo/presentation/auth/signup/widgets/title_text.dart';
 
+
+//테스트용 코드 route작업시 삭제
+//---------------------------------------
 void main() {
+    Get.put(MajorInterestController());
   runApp(
-    MaterialApp(
+    GetMaterialApp(
       home: MajorInterestSetupScreen(),
     ),
   );
 }
+//---------------------------------------
 
-class MajorInterestSetupScreen extends StatelessWidget {
+class MajorInterestSetupScreen extends GetView<MajorInterestController> {
   const MajorInterestSetupScreen({super.key});
 
   static const List<String> categories = [
@@ -48,65 +55,103 @@ class MajorInterestSetupScreen extends StatelessWidget {
                     AppStrings.majorInterestSelectionTitle,
                   ),
                   AppGap.v36,
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        '전공',
-                        style: AppTextStyles.textMedium(
-                          textColor: AppColors.gray80,
-                        ),
-                      ),
-                      AppGap.v4,
-                      Wrap(
-                        spacing: AppSpacing.s16,
-                        runSpacing: AppSpacing.s12,
-                        children: categories.map(
-                          (label) {
-                            return SelectableTag(
-                              label: label,
-                              isSelected: true,
-                            );
-                          },
-                        ).toList(),
-                      ),
-                      AppGap.v24,
-                      Text(
-                        '관심분야',
-                        style: AppTextStyles.textMedium(
-                          textColor: AppColors.gray80,
-                        ),
-                      ),
-                      AppGap.v4,
-                      Wrap(
-                        spacing: AppSpacing.s16,
-                        runSpacing: AppSpacing.s12,
-                        children: categories.map(
-                          (label) {
-                            return SelectableTag(
-                              label: label,
-                              isSelected: true,
-                            );
-                          },
-                        ).toList(),
-                      ),
-                    ],
-                  ),
+                  _buildMajorSelectSection(categories: categories),
+
+                  AppGap.v24,
+                  _buildInterestSection(categories: categories),
                 ],
               ),
-              Column(
-                children: [
-                  CustomButton(
-                    text: '다음',
-                    variant: ButtonVariant.primary,
-                  ),
-                  AppGap.v16,
-                ],
-              ),
+              _buildNextButton(),
             ],
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildInterestSection({
+    required List<String> categories,
+  }) {
+    return GetBuilder<MajorInterestController>(
+      builder: (controller) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '관심분야',
+              style: AppTextStyles.textMedium(
+                textColor: AppColors.gray80,
+              ),
+            ),
+            AppGap.v4,
+            Wrap(
+              spacing: AppSpacing.s16,
+              runSpacing: AppSpacing.s12,
+              children: categories.map(
+                (label) {
+                  return SelectableTag(
+                    label: label,
+                    isSelected: controller.selectedInterests.contains(label),
+                    onTap: () => controller.toggleInterest(label),
+                  );
+                },
+              ).toList(),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildMajorSelectSection({
+    required List<String> categories,
+  }) {
+    return GetBuilder<MajorInterestController>(
+      builder: (controller) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '전공',
+              style: AppTextStyles.textMedium(
+                textColor: AppColors.gray80,
+              ),
+            ),
+            AppGap.v4,
+            Wrap(
+              spacing: AppSpacing.s16,
+              runSpacing: AppSpacing.s12,
+              children: categories.map(
+                (label) {
+                  return SelectableTag(
+                    label: label,
+                    isSelected: controller.selectedMajor == label,
+                    onTap: () => controller.selectMajor(label),
+                  );
+                },
+              ).toList(),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildNextButton() {
+    return GetBuilder<MajorInterestController>(
+      builder: (controller) {
+        return Column(
+          children: [
+            CustomButton(
+              text: '다음',
+              variant: ButtonVariant.primary,
+              enabled: controller.canProceed,
+              onPressed: controller.canProceed ? controller.submit : null,
+            ),
+            AppGap.v16,
+          ],
+        );
+      },
     );
   }
 }
@@ -114,25 +159,30 @@ class MajorInterestSetupScreen extends StatelessWidget {
 class SelectableTag extends StatelessWidget {
   final String label;
   final bool isSelected;
+  final GestureTapCallback onTap;
 
   const SelectableTag({
     super.key,
     required this.label,
     required this.isSelected,
+    required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: AppPadding.chip,
-      decoration: BoxDecoration(
-        color: isSelected ? AppColors.gray20 : AppColors.primary,
-        borderRadius: AppRadius.baseRadius,
-      ),
-      child: Text(
-        label,
-        style: AppTextStyles.textMedium(
-          textColor: isSelected ? AppColors.black : AppColors.white,
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: AppPadding.chip,
+        decoration: BoxDecoration(
+          color: isSelected ? AppColors.primary : AppColors.gray20,
+          borderRadius: AppRadius.baseRadius,
+        ),
+        child: Text(
+          label,
+          style: AppTextStyles.textMedium(
+            textColor: isSelected ? AppColors.white : AppColors.black,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## 📌 개요

회원가입 과정에서 사용자가
전공과 관심분야를 선택할 수 있는 기능을 구현합니다.

---

## 🧩 작업 내용

- 전공 및 관심분야 선택 UI 퍼블리싱
- 전공 단일 선택 로직 구현
- 관심분야 다중 선택 로직 구현
- 선택 상태에 따른 태그 UI 상태 변경
- 선택 조건에 따른 다음 버튼 활성화 처리
- MajorInterestController를 통한 상태 관리
- UI와 Controller 연결 완료

---

## 📎 참고 사항

- 전공: 단일 선택
- 관심분야: 다중 선택
- 전공 + 관심분야 선택 시 다음 버튼 활성화

close #53 