### PR TITLE
[FEATURE] 설정 페이지 퍼블리싱

### DIFF
--- a/assets/image/menu.svg
+++ b/assets/image/menu.svg
@@ -1,0 +1,5 @@
+<svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 7.5C6 6.67157 6.67157 6 7.5 6C8.32843 6 9 6.67157 9 7.5C9 8.32843 8.32843 9 7.5 9C6.67157 9 6 8.32843 6 7.5Z" fill="#C7C7C7"/>
+<rect y="6" width="3" height="3" rx="1.5" fill="#C7C7C7"/>
+<rect x="12" y="6" width="3" height="3" rx="1.5" fill="#C7C7C7"/>
+</svg>

--- a/lib/core/design_system/app_icon.dart
+++ b/lib/core/design_system/app_icon.dart
@@ -21,6 +21,7 @@ enum AppIcon {
   searchUnFocus,
   send,
   star,
+  menu,
 
   chatSelect,
   chatUnSelect,
@@ -82,6 +83,8 @@ extension AppIconPath on AppIcon {
         return '$_basePath/send.svg';
       case AppIcon.star:
         return '$_basePath/star.png';
+      case AppIcon.menu:
+        return'$_basePath/menu.svg';
 
       case AppIcon.chatSelect:
         return '$_basePath/bottombar/chat_select.svg';

--- a/lib/core/design_system/app_layout.dart
+++ b/lib/core/design_system/app_layout.dart
@@ -13,25 +13,27 @@ class AppSpacing {
   static const double s16 = 16;
   static const double s18 = 18;
   static const double s24 = 24;
+  static const double s28 = 28;
   static const double s36 = 36;
   static const double s40 = 40;
+  static const double s42 = 42;
   static const double s51 = 51;
   static const double s76 = 76;
 }
 
 class AppGap {
-  static const SizedBox h4  = SizedBox(width: AppSpacing.s4);
-  static const SizedBox h6  = SizedBox(width: AppSpacing.s6);
-  static const SizedBox h8  = SizedBox(width: AppSpacing.s8);
+  static const SizedBox h4 = SizedBox(width: AppSpacing.s4);
+  static const SizedBox h6 = SizedBox(width: AppSpacing.s6);
+  static const SizedBox h8 = SizedBox(width: AppSpacing.s8);
   static const SizedBox h10 = SizedBox(width: AppSpacing.s10);
   static const SizedBox h12 = SizedBox(width: AppSpacing.s12);
   static const SizedBox h16 = SizedBox(width: AppSpacing.s16);
   static const SizedBox h24 = SizedBox(width: AppSpacing.s24);
   static const SizedBox h36 = SizedBox(width: AppSpacing.s36);
 
-  static const SizedBox v4  = SizedBox(height: AppSpacing.s4);
-  static const SizedBox v6  = SizedBox(height: AppSpacing.s6);
-  static const SizedBox v8  = SizedBox(height: AppSpacing.s8);
+  static const SizedBox v4 = SizedBox(height: AppSpacing.s4);
+  static const SizedBox v6 = SizedBox(height: AppSpacing.s6);
+  static const SizedBox v8 = SizedBox(height: AppSpacing.s8);
   static const SizedBox v10 = SizedBox(height: AppSpacing.s10);
   static const SizedBox v12 = SizedBox(height: AppSpacing.s12);
   static const SizedBox v16 = SizedBox(height: AppSpacing.s16);
@@ -40,7 +42,6 @@ class AppGap {
   static const SizedBox v40 = SizedBox(height: AppSpacing.s40);
   static const SizedBox v51 = SizedBox(height: AppSpacing.s51);
   static const SizedBox v76 = SizedBox(height: AppSpacing.s76);
-
 }
 
 class AppPadding {
@@ -76,10 +77,7 @@ class AppPadding {
     vertical: AppSpacing.s24,
   );
 
-  static const EdgeInsets topBar = EdgeInsets.symmetric(
-    horizontal: AppSpacing.s16,
-    vertical: AppSpacing.s16,
-  );
+  static const EdgeInsets topBar = EdgeInsets.all(AppSpacing.s16);
 
   static const EdgeInsets popUp = EdgeInsets.only(
     bottom: AppSpacing.s24,
@@ -88,6 +86,11 @@ class AppPadding {
   );
 
   static const EdgeInsets alertCount = EdgeInsets.all(AppSpacing.s2);
+
+  static const EdgeInsets settingSession = EdgeInsets.symmetric(
+    vertical: AppSpacing.s12,
+    horizontal: AppSpacing.s24,
+  );
 }
 
 class AppRadius {

--- a/lib/core/design_system/app_layout.dart
+++ b/lib/core/design_system/app_layout.dart
@@ -91,6 +91,8 @@ class AppPadding {
     vertical: AppSpacing.s12,
     horizontal: AppSpacing.s24,
   );
+
+  static const EdgeInsets terms = EdgeInsets.symmetric(horizontal: AppSpacing.s24);
 }
 
 class AppRadius {

--- a/lib/core/design_system/app_text_styles.dart
+++ b/lib/core/design_system/app_text_styles.dart
@@ -84,6 +84,13 @@ class AppTextStyles {
     );
   }
 
-
-
+  static TextStyle popupTitle({
+    Color? textColor,
+  }) {
+    return TextStyle(
+      color: textColor ?? AppColors.black,
+      fontSize: 20,
+      fontWeight: FontWeight.w600,
+    );
+  }
 }

--- a/lib/core/design_system/components/custom_back_button.dart
+++ b/lib/core/design_system/components/custom_back_button.dart
@@ -1,0 +1,66 @@
+import 'dart:developer';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+
+import '../app_colors.dart';
+import '../app_icon.dart';
+import '../app_layout.dart';
+import '../app_text_styles.dart';
+import 'custom_popup_menu_button.dart';
+
+class CustomBackButton extends StatelessWidget {
+  const CustomBackButton(
+      {
+    super.key,
+    required this.moreOptions,
+    this.itemBuilder,
+  });
+
+  final bool moreOptions;
+  final PopupMenuItemBuilder<String>? itemBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: AppPadding.topBar,
+      decoration: BoxDecoration(
+        boxShadow: [
+          BoxShadow(
+            color: Color(0x05781F07),
+            blurRadius: AppSpacing.s16,
+            offset: Offset(0, 16),
+            spreadRadius: 0,
+          ),
+        ],
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          GestureDetector(
+            onTap: () => log("프로필 이동"),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: [
+                SvgPicture.asset(AppIcon.arrowLeft.path),
+                AppGap.v4,
+                Text(
+                  "이전으로",
+                  style: AppTextStyles.textMedium(
+                    textColor: AppColors.gray60,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (moreOptions)
+            CustomPopupMenuButton(itemBuilder: itemBuilder!)
+          else
+            SizedBox(),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/core/design_system/components/custom_confirm_popup.dart
+++ b/lib/core/design_system/components/custom_confirm_popup.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:ondo/core/design_system/app_colors.dart';
+import 'package:ondo/core/design_system/app_layout.dart';
+import 'package:ondo/core/design_system/app_text_styles.dart';
+import 'package:ondo/core/design_system/component_variants.dart';
+import 'package:ondo/core/design_system/components/custom_button.dart';
+
+class CustomConfirmPopup extends StatelessWidget {
+  const CustomConfirmPopup({
+    super.key,
+    required this.title,
+    required this.description,
+    required this.confirmText,
+    required this.cancelText,
+    required this.onConfirm,
+    required this.onCancel,
+  });
+
+  final String title;
+  final String description;
+  final String confirmText;
+  final String cancelText;
+  final VoidCallback onConfirm;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      alignment: Alignment.center,
+      backgroundColor: AppColors.white,
+      insetPadding: AppPadding.screenHorizontal,
+      child: Container(
+        padding: AppPadding.actionPopup,
+        decoration: BoxDecoration(
+          borderRadius: AppRadius.popupRadius,
+          color: AppColors.white,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Center(child: Text(title, style: AppTextStyles.popupTitle())),
+            AppGap.v24,
+            Center(
+              child: Text(
+                description,
+                style: AppTextStyles.textMedium(),
+              ),
+            ),
+            AppGap.v24,
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Expanded(
+                  child: CustomButton(
+                    text: confirmText,
+                    variant: ButtonVariant.outline,
+                    hasBorder: true,
+                    onPressed: onConfirm,
+                  ),
+                ),
+                AppGap.h12,
+                Expanded(
+                  child: CustomButton(
+                    text: cancelText,
+                    variant: ButtonVariant.select,
+                    onPressed: onCancel,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/design_system/components/custom_popup_menu_button.dart
+++ b/lib/core/design_system/components/custom_popup_menu_button.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+
+import '../app_colors.dart';
+import '../app_icon.dart';
+import '../app_layout.dart';
+
+class CustomPopupMenuButton extends StatelessWidget {
+  const CustomPopupMenuButton({super.key, required this.itemBuilder});
+  final PopupMenuItemBuilder<String> itemBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+
+    return PopupMenuButton(
+      offset: const Offset(-6, 13),
+      color: AppColors.white,
+      borderRadius: AppRadius.baseRadius,
+      constraints: BoxConstraints(minWidth: 0),
+      itemBuilder: itemBuilder,
+      child: SvgPicture.asset(AppIcon.menu.path)
+    );
+  }
+}

--- a/lib/presentation/profile/screens/setting_screen.dart
+++ b/lib/presentation/profile/screens/setting_screen.dart
@@ -1,0 +1,112 @@
+import 'dart:developer';
+
+import 'package:flutter/material.dart';
+import 'package:ondo/core/design_system/app_layout.dart';
+import 'package:ondo/core/design_system/components/custom_back_button.dart';
+import 'package:ondo/core/ui/base/base_scaffold.dart';
+import 'package:ondo/presentation/profile/widget/build_app_version_session.dart';
+import 'package:ondo/presentation/profile/widget/build_custom_switch.dart';
+import 'package:ondo/presentation/profile/widget/custom_setting_item.dart';
+import 'package:ondo/presentation/profile/widget/user_delete_popup.dart';
+
+void main() {
+  runApp(
+    MaterialApp(
+      home: SettingScreen(),
+    ),
+  );
+}
+
+class SettingScreen extends StatefulWidget {
+  const SettingScreen({super.key});
+
+  @override
+  State<SettingScreen> createState() => _SettingScreenState();
+}
+
+class _SettingScreenState extends State<SettingScreen> {
+  bool isPushState = false;
+  bool isVibrationState = false;
+  bool isSoundState = false;
+  bool isOnLine = false;
+  bool isOptions = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: BaseScaffold(
+        body: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            CustomBackButton(moreOptions: false),
+            AppGap.v16,
+            Container(
+              width: MediaQuery.of(context).size.width,
+              padding: AppPadding.settingSession,
+              child: Column(
+                children: [
+                  BuildCustomSwitch(
+                    name: "푸시알람",
+                    value: isPushState,
+                    onChanged: (value) => setState(() {
+                      isPushState = !isPushState;
+                      isVibrationState = false;
+                      isSoundState = false;
+                    }),
+                  ),
+                  AppGap.v24,
+                  //진동알람
+                  BuildCustomSwitch(
+                    name: "ㄴ 진동알람",
+                    value: isVibrationState,
+                    onChanged: (value) => setState(() {
+                      isVibrationState = !isVibrationState;
+                    }),
+                  ),
+                  AppGap.v16,
+                  //소리알람
+                  BuildCustomSwitch(
+                    name: "ㄴ 소리알람",
+                    value: isSoundState,
+                    onChanged: (value) => setState(() {
+                      isSoundState = !isSoundState;
+                    }),
+                  ),
+                  AppGap.v24,
+                  //온라인 표시
+                  BuildCustomSwitch(
+                    name: "다른 사람에게 온라인 표시",
+                    value: isOnLine,
+                    onChanged: (value) => setState(() {
+                      isOnLine = !isOnLine;
+                    }),
+                  ),
+                ],
+              ),
+            ),
+            AppGap.v16,
+            Container(
+              width: MediaQuery.of(context).size.width,
+              padding: AppPadding.settingSession,
+              child: Column(
+                children: [
+                  CustomSettingItem(
+                    name: "이용약관",
+                    onTap: () => log('이용약관'),
+                  ),
+                  AppGap.v24,
+                  CustomSettingItem(
+                    name: "회원탈퇴",
+                    onTap: () => UserDeletePopup.userDeletePopup(context),
+                  ),
+                ],
+              ),
+            ),
+            AppGap.v16,
+            BuildAppVersionSession(),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/profile/screens/terms_screen.dart
+++ b/lib/presentation/profile/screens/terms_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:ondo/core/design_system/app_colors.dart';
+import 'package:ondo/core/design_system/app_layout.dart';
+import 'package:ondo/core/design_system/app_strings.dart';
+import 'package:ondo/core/design_system/app_text_styles.dart';
+import 'package:ondo/core/design_system/components/custom_back_button.dart';
+import 'package:ondo/core/ui/base/base_scaffold.dart';
+
+void main() {
+  runApp(
+    MaterialApp(
+      home: TermsScreen(),
+    ),
+  );
+}
+
+class TermsScreen extends StatelessWidget {
+  const TermsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: BaseScaffold(
+        body: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            CustomBackButton(moreOptions: false),
+            AppGap.v16,
+            Container(
+              margin: AppPadding.terms,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    padding: AppPadding.topBar,
+                    decoration: BoxDecoration(
+                      color: AppColors.gray20,
+                      borderRadius: AppRadius.baseRadius,
+                    ),
+                    child: Text(AppStrings.privacyAgreementContent),
+                  ),
+                  AppGap.v16,
+                  Text(
+                    "2026 - 01- 12에 동의한 개인정보 수집 내용입니다",
+                    style: AppTextStyles.textMedium(
+                      textColor: AppColors.gray50,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/profile/widget/build_app_version_session.dart
+++ b/lib/presentation/profile/widget/build_app_version_session.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/design_system/app_colors.dart';
+import '../../../core/design_system/app_layout.dart';
+import '../../../core/design_system/app_text_styles.dart';
+
+class BuildAppVersionSession extends StatelessWidget {
+  const BuildAppVersionSession({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: MediaQuery.of(context).size.width,
+      padding: AppPadding.settingSession,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            "앱버젼",
+            style: AppTextStyles.textMedium(
+              textColor: AppColors.black,
+            ),
+          ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(
+                "4.56",
+                style: AppTextStyles.textMedium(
+                  textColor: AppColors.gray40,
+                ),
+              ),
+              Text(
+                "최신 버전을 사용중입니다",
+                style: AppTextStyles.textMedium(
+                  textColor: AppColors.gray40,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/profile/widget/build_custom_switch.dart
+++ b/lib/presentation/profile/widget/build_custom_switch.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:ondo/core/design_system/app_colors.dart';
+import 'package:ondo/core/design_system/app_layout.dart';
+import 'package:ondo/core/design_system/app_text_styles.dart';
+
+class BuildCustomSwitch extends StatelessWidget {
+  const BuildCustomSwitch({
+    super.key,
+    required this.name,
+    required this.value,
+    this.onChanged,
+  });
+
+  final String name;
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          name,
+          style: AppTextStyles.textMedium(
+            textColor: AppColors.gray90,
+          ),
+        ),
+        SizedBox(
+          height: AppSpacing.s28,
+          width: AppSpacing.s42,
+          child: FittedBox(
+            fit: BoxFit.fill,
+            child: CupertinoSwitch(
+              focusColor: AppColors.primary,
+              activeTrackColor: AppColors.primary,
+              inactiveThumbColor: AppColors.gray40,
+              inactiveTrackColor: AppColors.gray20,
+              value: value,
+              trackOutlineColor: WidgetStateProperty.all(Colors.transparent),
+              onChanged: onChanged,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/profile/widget/custom_setting_item.dart
+++ b/lib/presentation/profile/widget/custom_setting_item.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+
+import '../../../core/design_system/app_colors.dart';
+import '../../../core/design_system/app_icon.dart';
+import '../../../core/design_system/app_text_styles.dart';
+
+class CustomSettingItem extends StatelessWidget {
+  const CustomSettingItem({
+    super.key,
+    required this.name,
+    required this.onTap,
+  });
+
+  final String name;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            name,
+            style: AppTextStyles.textMedium(
+              textColor: (name == "회원탈퇴") ? AppColors.red : AppColors.gray90,
+            ),
+          ),
+          RotatedBox(
+            quarterTurns: 2,
+            child: SvgPicture.asset(
+              colorFilter: ColorFilter.mode(
+                AppColors.gray40,
+                BlendMode.srcIn,
+              ),
+              AppIcon.arrowLeft.path,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/profile/widget/user_delete_popup.dart
+++ b/lib/presentation/profile/widget/user_delete_popup.dart
@@ -1,9 +1,7 @@
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
-import 'package:ondo/core/design_system/app_colors.dart';
-import 'package:ondo/core/design_system/app_layout.dart';
-import 'package:ondo/core/design_system/app_text_styles.dart';
-import 'package:ondo/core/design_system/component_variants.dart';
-import 'package:ondo/core/design_system/components/custom_button.dart';
+import 'package:ondo/core/design_system/components/custom_confirm_popup.dart';
 
 class UserDeletePopup {
   static Future<void> userDeletePopup(BuildContext context) {
@@ -11,54 +9,13 @@ class UserDeletePopup {
       context: context,
       barrierDismissible: false,
       builder: (context) {
-        return Dialog(
-          alignment: Alignment.center,
-          backgroundColor: AppColors.white,
-          insetPadding: AppPadding.screenHorizontal,
-          child: Container(
-            padding: AppPadding.actionPopup,
-            decoration: BoxDecoration(
-              borderRadius:AppRadius.popupRadius,
-              color: AppColors.white,
-            ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Center(child: Text("회원탈퇴", style: AppTextStyles.popupTitle())),
-                AppGap.v24,
-                Center(
-                  child: Text(
-                    '정말로 탈퇴하시겠습니까?',
-                    style: AppTextStyles.textMedium(),
-                  ),
-                ),
-                AppGap.v24,
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Expanded(
-                      child: CustomButton(
-                        text: "회원탈퇴",
-                        variant: ButtonVariant.outline,
-                        hasBorder: true,
-                        onPressed: () {
-                          Navigator.of(context).pop();
-                        },
-                      ),
-                    ),
-                    AppGap.h12,
-                    Expanded(
-                      child: CustomButton(
-                        text: "아니오",
-                        variant: ButtonVariant.select,
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
+        return CustomConfirmPopup(
+          title: "회원탈퇴",
+          description: "정말로 탈퇴하시겠습니까?",
+          confirmText: "회원탈퇴",
+          cancelText: "아니오",
+          onConfirm: () => log("회원탈퇴"),
+          onCancel: () => Navigator.pop(context),
         );
       },
     );

--- a/lib/presentation/profile/widget/user_delete_popup.dart
+++ b/lib/presentation/profile/widget/user_delete_popup.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:ondo/core/design_system/app_colors.dart';
+import 'package:ondo/core/design_system/app_layout.dart';
+import 'package:ondo/core/design_system/app_text_styles.dart';
+import 'package:ondo/core/design_system/component_variants.dart';
+import 'package:ondo/core/design_system/components/custom_button.dart';
+
+class UserDeletePopup {
+  static Future<void> userDeletePopup(BuildContext context) {
+    return showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        return Dialog(
+          alignment: Alignment.center,
+          backgroundColor: AppColors.white,
+          insetPadding: AppPadding.screenHorizontal,
+          child: Container(
+            padding: AppPadding.actionPopup,
+            decoration: BoxDecoration(
+              borderRadius:AppRadius.popupRadius,
+              color: AppColors.white,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Center(child: Text("회원탈퇴", style: AppTextStyles.popupTitle())),
+                AppGap.v24,
+                Center(
+                  child: Text(
+                    '정말로 탈퇴하시겠습니까?',
+                    style: AppTextStyles.textMedium(),
+                  ),
+                ),
+                AppGap.v24,
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Expanded(
+                      child: CustomButton(
+                        text: "회원탈퇴",
+                        variant: ButtonVariant.outline,
+                        hasBorder: true,
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                        },
+                      ),
+                    ),
+                    AppGap.h12,
+                    Expanded(
+                      child: CustomButton(
+                        text: "아니오",
+                        variant: ButtonVariant.select,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## 📌 개요

프로필 내 설정 페이지 퍼블리싱 작업  
알림 설정, 정보, 계정 섹션을 포함한 설정 화면 전체 UI 구현

---

## 🧩 작업 내용

- [x] 설정 화면 기본 레이아웃 구성 (AppBar, Scroll 구조)
- [x] 알림 설정 섹션 UI 구현 (푸시 / 소리 / 진동 토글)
- [x] 정보 섹션 UI 구현 (이용약관 / 개인정보 처리방침 / 앱 버전)
- [x] 계정 섹션 UI 구현 (로그아웃 / 회원 탈퇴 버튼)
- [x] 회원 탈퇴 팝업 UI 연결
- [x] 설정 전용 위젯 분리 및 적용
- [x] 더미 상태 기반 Switch 동작 구현

---

## 📎 참고 사항

- 기능명세서 설정 항목 기준 구현
- 디자인 시안 기반 UI 퍼블리싱
- API 연동은 제외 (추후 이슈로 진행 예정)

close #62 
