### PR TITLE
[Feature] 비밀번호 재설정 화면 퍼블리싱

### DIFF
--- a/lib/core/design_system/app_strings.dart
+++ b/lib/core/design_system/app_strings.dart
@@ -63,21 +63,21 @@ class AppStrings {
   static const ruleViolationWarning =
       '위 규칙을 상습적으로 지키지 않을 시에 관리자에게 \n제재를 받을 수 있어요!';
 
-  static const emailCodeInputHint =
-      '인증번호 6자리를 입력해주세요';
+  static const emailCodeInputHint = '인증번호 6자리를 입력해주세요';
 
-  static const invalidEmailCode =
-      '인증번호가 올바르지 않아요. 다시 확인해주세요';
+  static const invalidEmailCode = '인증번호가 올바르지 않아요. 다시 확인해주세요';
 
-  static const inputEmailAndPassword =
-  '이메일과 비밀번호를 입력해주세요.';
+  static const inputEmailAndPassword = '이메일과 비밀번호를 입력해주세요.';
 
-  static const emailRegex =
-  '이메일 형식이 올바르지 않아요.';
+  static const emailRegex = '이메일 형식이 올바르지 않아요.';
 
-  static const passwordLength =
-  '비밀번호는 8~15자여야 해요.';
+  static const passwordLength = '비밀번호는 8~15자여야 해요.';
 
-  static const passwordRegex =
-  '비밀번호에 특수기호를 포함해주세요.';
+  static const passwordRegex = '비밀번호에 특수기호를 포함해주세요.';
+
+  static const passwordResetEmail = '계정에 등록된\n이메일을 입력해주세요';
+
+  static const passwordResetPassword = '계정의 비밀번호를\n다시 설정해주세요';
+
+  static const passwordResetCompleted = '비밀번호 재설정이 완료되었어요!\n메인 화면에서 로그인해주세요!';
 }

--- a/lib/presentation/password_find/controllers/password_find_password_controller.dart
+++ b/lib/presentation/password_find/controllers/password_find_password_controller.dart
@@ -6,7 +6,7 @@ import 'package:ondo/presentation/auth/signup/states/input_validation_state.dart
 class PasswordResetController extends GetxController {
   static const int mainPasswordLength = 8;
   static const String passwordPattern =
-      r'^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$';
+      r'^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$';
 
   final passwordController = TextEditingController();
   final confirmPasswordController = TextEditingController();

--- a/lib/presentation/password_find/controllers/password_find_password_controller.dart
+++ b/lib/presentation/password_find/controllers/password_find_password_controller.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:ondo/core/design_system/app_strings.dart';
+import 'package:ondo/presentation/auth/signup/states/input_validation_state.dart';
+
+class PasswordResetController extends GetxController {
+  static const int mainPasswordLength = 8;
+  static const String passwordPattern =
+      r'^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$';
+
+  final passwordController = TextEditingController();
+  final confirmPasswordController = TextEditingController();
+
+  final RxBool isObscure = true.obs;
+  final Rx<InputValidationState> state = InputValidationState.initial.obs;
+
+  final RxBool hasInput = false.obs;
+
+  /// 버튼 클릭 여부
+  bool _submitted = false;
+
+  @override
+  void onInit() {
+    super.onInit();
+    passwordController.addListener(_onTextChanged);
+    confirmPasswordController.addListener(_onTextChanged);
+  }
+
+  void toggleObscure() => isObscure.toggle();
+
+  void _onTextChanged() {
+    hasInput.value =
+        passwordController.text.isNotEmpty ||
+            confirmPasswordController.text.isNotEmpty;
+
+
+    if(_submitted){
+      _validate();
+    }
+  }
+
+  /// 버튼 클릭 시 호출
+  void submit() {
+    _submitted = true;
+    _validate();
+  }
+
+  void _validate() {
+    final password = passwordController.text;
+    final confirm = confirmPasswordController.text;
+
+    if (password.isEmpty || confirm.isEmpty) {
+      state.value = InputValidationState.invalid;
+      return;
+    }
+
+    if (!_isValidPassword(password)) {
+      state.value = InputValidationState.invalid;
+      return;
+    }
+
+    if (password != confirm) {
+      state.value = InputValidationState.mismatch;
+      return;
+    }
+
+    state.value = InputValidationState.valid;
+  }
+
+  bool _isValidPassword(String password) {
+    return RegExp(passwordPattern).hasMatch(password);
+  }
+
+  bool get canProceed => state.value == InputValidationState.valid;
+
+  String? get passwordErrorText {
+    if (!_submitted) return null;
+
+    if (state.value == InputValidationState.invalid) {
+      return '$mainPasswordLength자 이상, 영문+숫자 조합이 필요합니다.';
+    }
+    return null;
+  }
+
+  String? get confirmPasswordErrorText {
+    if (!_submitted && state.value != InputValidationState.mismatch) return null;
+
+    if (state.value == InputValidationState.mismatch) {
+      return AppStrings.invalidPassword;
+    }
+    return null;
+  }
+
+  @override
+  void onClose() {
+    passwordController.dispose();
+    confirmPasswordController.dispose();
+    super.onClose();
+  }
+}

--- a/lib/presentation/password_find/controllers/password_find_password_controller.dart
+++ b/lib/presentation/password_find/controllers/password_find_password_controller.dart
@@ -75,9 +75,14 @@ class PasswordResetController extends GetxController {
 
   String? get passwordErrorText {
     if (!_submitted) return null;
+    final password = passwordController.text;
+    
+    if(password.length < mainPasswordLength) {
+      return AppStrings.passwordLength;
+    }
 
-    if (state.value == InputValidationState.invalid) {
-      return '$mainPasswordLength자 이상, 영문+숫자 조합이 필요합니다.';
+    if (!_isValidPassword(password)) {
+      return AppStrings.passwordRegex;
     }
     return null;
   }

--- a/lib/presentation/password_find/screens/password_find_email_code_screen.dart
+++ b/lib/presentation/password_find/screens/password_find_email_code_screen.dart
@@ -24,7 +24,7 @@ class PasswordFindEmailCodeInputScreen
     return SafeArea(
       child: BaseScaffold(
         body: Padding(
-          padding: AppPadding.screenHorizontal,
+          padding: AppPadding.titleTextHorizontal,
           child: Column(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [

--- a/lib/presentation/password_find/screens/password_find_passoword_screen.dart
+++ b/lib/presentation/password_find/screens/password_find_passoword_screen.dart
@@ -1,0 +1,147 @@
+import 'dart:developer';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:get/get.dart';
+import 'package:ondo/core/design_system/app_colors.dart';
+import 'package:ondo/core/design_system/app_layout.dart';
+import 'package:ondo/core/design_system/app_strings.dart';
+import 'package:ondo/core/design_system/app_text_styles.dart';
+import 'package:ondo/core/design_system/component_variants.dart';
+import 'package:ondo/core/design_system/components/custom_button.dart';
+import 'package:ondo/core/design_system/components/custom_textfield.dart';
+import 'package:ondo/core/ui/base/base_scaffold.dart';
+import 'package:ondo/presentation/password_find/controllers/password_find_password_controller.dart';
+import '../../../../core/design_system/app_icon.dart';
+
+void main() {
+  runApp(
+    MaterialApp(
+      home: PasswordResetCompleted(controller: Get.put(PasswordResetController())),
+    ),
+  );
+}
+
+class PasswordResetCompleted extends StatelessWidget {
+  final PasswordResetController controller;
+
+  const PasswordResetCompleted({
+    super.key,
+    required this.controller,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      body: Padding(
+        padding: AppPadding.screenHorizontal,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+                keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+                child: _buildForm(),
+              ),
+            ),
+            _buildNextButton(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildForm() {
+    return Obx(() {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          AppGap.v76,
+          Text(
+            AppStrings.passwordResetPassword,
+            style: AppTextStyles.titleSm(),
+          ),
+          AppGap.v36,
+          LabelTextField(
+            label: '비밀번호',
+            controller: controller.passwordController,
+            hintText: AppStrings.passwordInputHint,
+            obscureText: controller.isObscure.value,
+            errorText: controller.passwordErrorText,
+          ),
+          AppGap.v24,
+          LabelTextField(
+            label: '비밀번호 확인',
+            controller: controller.confirmPasswordController,
+            hintText: AppStrings.passwordCheckHint,
+            obscureText: controller.isObscure.value,
+            errorText: controller.confirmPasswordErrorText,
+          ),
+          AppGap.v8,
+          _buildPasswordToggle(),
+        ],
+      );
+    });
+  }
+
+  Widget _buildPasswordToggle() {
+    return Obx(() {
+      return GestureDetector(
+        onTap: controller.toggleObscure,
+        behavior: HitTestBehavior.opaque,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SvgPicture.asset(
+                controller.isObscure.value
+                    ? AppIcon.check.path
+                    : AppIcon.checkOn.path,
+              ),
+              AppGap.h6,
+              Text(
+                '비밀번호 표시',
+                style: AppTextStyles.textMedium(
+                  textColor: controller.isObscure.value
+                      ? AppColors.gray50
+                      : AppColors.primary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    });
+  }
+
+  Widget _buildNextButton() {
+    return Obx(() {
+      return Column(
+        children: [
+          CustomButton(
+            text: '다음',
+            variant: ButtonVariant.primary,
+            enabled: controller.hasInput.value,
+            onPressed: () {
+              controller.submit();
+              if (controller.canProceed) {
+                _handleNext();
+              }
+            },
+          ),
+          AppGap.v16,
+        ],
+      );
+    });
+  }
+
+  void _handleNext() {
+    assert(() {
+      log('비밀번호 설정 완료');
+      return true;
+    }());
+
+    // context.push('/next');
+  }
+}

--- a/lib/presentation/password_find/screens/password_find_passoword_screen.dart
+++ b/lib/presentation/password_find/screens/password_find_passoword_screen.dart
@@ -26,7 +26,7 @@ class PasswordReset extends StatelessWidget {
   Widget build(BuildContext context) {
     return BaseScaffold(
       body: Padding(
-        padding: AppPadding.screenHorizontal,
+        padding: AppPadding.titleTextHorizontal,
         child: Column(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [

--- a/lib/presentation/password_find/screens/password_find_passoword_screen.dart
+++ b/lib/presentation/password_find/screens/password_find_passoword_screen.dart
@@ -14,10 +14,10 @@ import 'package:ondo/core/ui/base/base_scaffold.dart';
 import 'package:ondo/presentation/password_find/controllers/password_find_password_controller.dart';
 import '../../../../core/design_system/app_icon.dart';
 
-class PasswordResetCompleted extends StatelessWidget {
+class PasswordReset extends StatelessWidget {
   final PasswordResetController controller;
 
-  const PasswordResetCompleted({
+  const PasswordReset({
     super.key,
     required this.controller,
   });

--- a/lib/presentation/password_find/screens/password_find_passoword_screen.dart
+++ b/lib/presentation/password_find/screens/password_find_passoword_screen.dart
@@ -14,14 +14,6 @@ import 'package:ondo/core/ui/base/base_scaffold.dart';
 import 'package:ondo/presentation/password_find/controllers/password_find_password_controller.dart';
 import '../../../../core/design_system/app_icon.dart';
 
-void main() {
-  runApp(
-    MaterialApp(
-      home: PasswordResetCompleted(controller: Get.put(PasswordResetController())),
-    ),
-  );
-}
-
 class PasswordResetCompleted extends StatelessWidget {
   final PasswordResetController controller;
 

--- a/lib/presentation/password_find/screens/password_find_password_completed.dart
+++ b/lib/presentation/password_find/screens/password_find_password_completed.dart
@@ -10,15 +10,15 @@ import 'package:ondo/core/ui/base/base_scaffold.dart';
 void main() {
   runApp(
     MaterialApp(
-      home: PasswordSetupScreen(email: 'bulgom.com'),
+      home: PasswordResetCompletedScreen(email: 'bulgom.com'),
     ),
   );
 }
 
-class PasswordSetupScreen extends StatelessWidget {
+class PasswordResetCompletedScreen extends StatelessWidget {
   final String email;
 
-  const PasswordSetupScreen({super.key, required this.email});
+  const PasswordResetCompletedScreen({super.key, required this.email});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/password_find/screens/password_find_password_completed.dart
+++ b/lib/presentation/password_find/screens/password_find_password_completed.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:ondo/core/design_system/app_colors.dart';
+import 'package:ondo/core/design_system/app_layout.dart';
+import 'package:ondo/core/design_system/app_strings.dart';
+import 'package:ondo/core/design_system/app_text_styles.dart';
+import 'package:ondo/core/design_system/component_variants.dart';
+import 'package:ondo/core/design_system/components/custom_button.dart';
+import 'package:ondo/core/ui/base/base_scaffold.dart';
+
+void main() {
+  runApp(
+    MaterialApp(
+      home: PasswordSetupScreen(email: 'bulgom.com'),
+    ),
+  );
+}
+
+class PasswordSetupScreen extends StatelessWidget {
+  final String email;
+
+  const PasswordSetupScreen({super.key, required this.email});
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      body: Padding(
+        padding: AppPadding.screenHorizontal,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            AppGap.v51,
+            Text(
+              '$email로 회원가입된 계정의',
+              style: AppTextStyles.caption(textColor: AppColors.gray70),
+            ),
+            AppGap.v8,
+            Text(
+              AppStrings.passwordResetCompleted,
+              style: AppTextStyles.titleSm(),
+            ),
+            Spacer(flex: 1),
+            Column(
+              children: [
+                CustomButton(
+                  text: '다음',
+                  variant: ButtonVariant.primary,
+                  onPressed: () {},
+                ),
+                AppGap.v16,
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/password_find/screens/password_find_password_completed.dart
+++ b/lib/presentation/password_find/screens/password_find_password_completed.dart
@@ -7,13 +7,6 @@ import 'package:ondo/core/design_system/component_variants.dart';
 import 'package:ondo/core/design_system/components/custom_button.dart';
 import 'package:ondo/core/ui/base/base_scaffold.dart';
 
-void main() {
-  runApp(
-    MaterialApp(
-      home: PasswordResetCompletedScreen(email: 'bulgom.com'),
-    ),
-  );
-}
 
 class PasswordResetCompletedScreen extends StatelessWidget {
   final String email;

--- a/lib/presentation/password_find/screens/password_find_password_completed.dart
+++ b/lib/presentation/password_find/screens/password_find_password_completed.dart
@@ -17,7 +17,7 @@ class PasswordResetCompletedScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return BaseScaffold(
       body: Padding(
-        padding: AppPadding.screenHorizontal,
+        padding: AppPadding.titleTextHorizontal,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [


### PR DESCRIPTION
## 📌 개요

비밀번호 찾기 시, 사용자가 등록된 이메일을 입력하고 유효성을 검사한 후 인증번호를 발송할 수 있는 화면을 구현했습니다.
이메일 형식 검증 및 에러 메시지 표시 로직을 포함합니다.

---

## 🧩 작업 내용

* [x] 비밀번호 찾기 비밀번호 재설정 화면 구현
* [x] 비밀번호 8자이상, 특수문자 포함으로 구현
* [x] 비밀번호, 비밀번호 텍스트 값이 일치하는지 확인 구현
* [x] 에러 발생 시 입력 텍스트 및 에러 문구 스타일 적용
* [x] 비밀번호 재설정 완료 화면 구현

---

## 📎 참고 사항

- 디자인 시안 
- API 명세서
 - 참고 링크

---

close #73 