### PR TITLE
[FEATURE] 회원가입 플로우 라우팅

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,53 +1,147 @@
 import 'package:flutter/material.dart';
+import 'package:get/get_core/src/get_main.dart';
+import 'package:get/get_instance/src/extension_instance.dart';
 import 'package:go_router/go_router.dart';
+import 'package:ondo/presentation/auth/signup/controllers/email_code_input_controller.dart';
+import 'package:ondo/presentation/auth/signup/controllers/email_input_controller.dart';
+import 'package:ondo/presentation/auth/signup/controllers/introduction_input_controller.dart';
+import 'package:ondo/presentation/auth/signup/controllers/major_interest_controller.dart';
+import 'package:ondo/presentation/auth/signup/controllers/nickname_input_controller.dart';
+import 'package:ondo/presentation/auth/signup/controllers/password_input_controller.dart';
+import 'package:ondo/presentation/auth/signup/controllers/profile_image_setup_controller.dart';
+import 'package:ondo/presentation/auth/signup/controllers/signup_flow_controller.dart';
+import 'package:ondo/presentation/auth/signup/controllers/terms_agreement_controller.dart';
+import 'package:ondo/presentation/auth/signup/screens/email_code_input_screen.dart';
+import 'package:ondo/presentation/auth/signup/screens/email_input_screen.dart';
+import 'package:ondo/presentation/auth/signup/screens/introduction_input_screen.dart';
+import 'package:ondo/presentation/auth/signup/screens/major_interest_setup_screen.dart';
+import 'package:ondo/presentation/auth/signup/screens/nickname_setup_screen.dart';
+import 'package:ondo/presentation/auth/signup/screens/password_setup_screen.dart';
+import 'package:ondo/presentation/auth/signup/screens/profile_image_setup_screen.dart';
+import 'package:ondo/presentation/auth/signup/screens/signup_complete_screen.dart';
+import 'package:ondo/presentation/auth/signup/screens/terms_agreement_screen.dart';
+import 'package:ondo/presentation/home/screens/home_screen.dart';
 
 class RoutePaths {
   static const String home = '/';
   static const String login = '/login';
-  static const String signup = '/signup';
   static const String profile = '/profile';
+
+  static const String signup = '/signup';
+  static const String signupTerms = '/signup/terms';
+  static const String signupEmail = '/signup/email';
+  static const String signupEmailCode = '/signup/email-code';
+  static const String signupPassword = '/signup/password';
+  static const String signupNickname = '/signup/nickname';
+  static const String signupProfileImage = '/signup/profile-image';
+  static const String signupIntroduction = '/signup/introduction';
+  static const String signupMajorInterest = '/signup/major-interest';
+  static const String signupComplete = '/signup/complete';
 }
 
 final GoRouter appRouter = GoRouter(
-  initialLocation: RoutePaths.home,
+  initialLocation: RoutePaths.signupTerms,
   routes: [
     GoRoute(
       path: RoutePaths.home,
       name: 'home',
-      builder: (context, state) => Scaffold(
-        body: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Text('홈페이지'),
-            ElevatedButton(
-              onPressed: () => context.goNamed('login'),
-              child: Text('로그인'),
-            ),
-          ],
-        ),
-      ),
-    ),
+      builder: (context, state) => HomeScreen(),
+    ), //home
     GoRoute(
       path: RoutePaths.login,
       name: 'login',
       builder: (context, state) => Scaffold(
         body: Text('로그인페이지'),
       ),
-    ),
+    ), //login
     GoRoute(
       path: RoutePaths.profile,
       name: 'profile',
       builder: (context, state) => Scaffold(
         body: Text('프로필'),
       ),
-    ),
+    ), //profile
+
     GoRoute(
       path: RoutePaths.signup,
       name: 'signup',
-      builder: (context, state) => Scaffold(
-        body: Text('회원가입페이지'),
-      ),
+      builder: (context, state) {
+        Get.put(SignupFlowController(), permanent: true);
+        return const SizedBox();
+      },
+      routes: [
+        GoRoute(
+          path: 'terms',
+          name: "signupTerms",
+          builder: (context, state) {
+            Get.put(TermsAgreementController());
+            return TermsAgreementScreen();
+          },
+        ),
+        GoRoute(
+          path: 'email',
+          name: "signupEmail",
+          builder: (context, state) {
+            Get.put(EmailInputController());
+            return EmailInputScreen();
+          },
+        ),
+        GoRoute(
+          path: 'email-code',
+          name: "signupEmailCode",
+          builder: (context, state) {
+            Get.put(EmailCodeInputController());
+            return EmailCodeInputScreen();
+          },
+        ),
+        GoRoute(
+          path: 'password',
+          name: "signupPassword",
+          builder: (context, state) {
+            Get.put(PasswordInputController());
+            return PasswordSetupScreen();
+          },
+        ),
+        GoRoute(
+          path: 'nickname',
+          name: "signupNickname",
+          builder: (context, state) {
+            Get.put(NicknameInputController());
+            return NicknameSetupScreen();
+          },
+        ),
+        GoRoute(
+          path: 'profile-image',
+          name: "signupProfileImage",
+          builder: (context, state) {
+            Get.put(ProfileImageSetupController());
+            return ProfileImageSetupScreen();
+          },
+        ),
+        GoRoute(
+          path: 'introduction',
+          name: "signupIntroduction",
+          builder: (context, state) {
+            Get.put(IntroductionInputController());
+            return IntroductionInputScreen();
+          },
+        ),
+        GoRoute(
+          path: 'major-interest',
+          name: "signupMajorInterest",
+          builder: (context, state) {
+            Get.put(MajorInterestController());
+            return MajorInterestSetupScreen();
+          },
+        ),
+        GoRoute(
+          path: 'complete',
+          name: "signupComplete",
+          builder: (context, state) {
+            return SignupCompleteScreen();
+          },
+        ),
+      ],
     ),
   ],
   errorBuilder: (context, state) => Scaffold(

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -40,7 +40,7 @@ class RoutePaths {
 }
 
 final GoRouter appRouter = GoRouter(
-  initialLocation: RoutePaths.signupTerms,
+  initialLocation: RoutePaths.home,
   routes: [
     GoRoute(
       path: RoutePaths.home,
@@ -65,9 +65,11 @@ final GoRouter appRouter = GoRouter(
     GoRoute(
       path: RoutePaths.signup,
       name: 'signup',
-      builder: (context, state) {
-        Get.put(SignupFlowController(), permanent: true);
-        return const SizedBox();
+      redirect: (context, state) {
+        Get.lazyPut(() => SignupFlowController());
+        if(state.matchedLocation == RoutePaths.signup){
+          return RoutePaths.signupTerms;
+        }return null;
       },
       routes: [
         GoRoute(

--- a/lib/presentation/auth/signup/screens/password_setup_screen.dart
+++ b/lib/presentation/auth/signup/screens/password_setup_screen.dart
@@ -15,21 +15,8 @@ import 'package:ondo/presentation/auth/signup/controllers/password_input_control
 
 import '../../../../core/design_system/app_icon.dart';
 
-void main() {
-  runApp(
-    MaterialApp(
-      home: PasswordSetupScreen(controller: Get.put(PasswordInputController())),
-    ),
-  );
-}
-
-class PasswordSetupScreen extends StatelessWidget {
-  final PasswordInputController controller;
-
-  const PasswordSetupScreen({
-    super.key,
-    required this.controller,
-  });
+class PasswordSetupScreen extends GetView<PasswordInputController> {
+  const PasswordSetupScreen({super.key});
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## 📌 개요

> go_router 기반 회원가입 플로우 라우팅 구조를 설계하고,
> 각 단계별 화면에 네비게이션을 연결하여 회원가입 전체 흐름을 완성했습니다.

---

## 🧩 작업 내용

- [x] app_router.dart에 회원가입 단계별 route 경로 정의
- [x] 회원가입 순서 기반 네비게이션 구조 구성
  (약관 → 이메일 → 인증코드 → 비밀번호 → 닉네임 → 프로필 이미지 → 자기소개 → 전공/관심사 → 완료)
- [x] 각 step screen에 context.push 적용
- [x] SignupFlowController와 단계별 화면 상태 흐름 연결
- [x] 회원가입 완료 화면까지 전체 플로우 동작 확인

---

## 📎 참고 사항

- go_router 기반 라우팅 구조 사용
- 회원가입 데이터는 SignupFlowController를 통해 단계별로 누적 관리
- 이후 API 연동 시 해당 플로우를 기반으로 요청 예정

close #71 