### PR TITLE
[FEATURE] 프로필 라우팅 구조 설계 및 연결 

### DIFF
--- a/lib/core/design_system/components/custom_back_button.dart
+++ b/lib/core/design_system/components/custom_back_button.dart
@@ -1,5 +1,3 @@
-import 'dart:developer';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 
@@ -41,16 +39,13 @@ class CustomBackButton extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          GestureDetector(
-            onTap: () => log("프로필 이동"),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              mainAxisAlignment: MainAxisAlignment.start,
-              children: [
-                SvgPicture.asset(AppIcon.arrowLeft.path),
-                if (!useUserProfile) _text() else _profile(),
-              ],
-            ),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: [
+              SvgPicture.asset(AppIcon.arrowLeft.path),
+              if (!useUserProfile) _text() else _profile(),
+            ],
           ),
           if (moreOptions)
             CustomPopupMenuButton(itemBuilder: itemBuilder!)

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -21,11 +21,21 @@ import 'package:ondo/presentation/auth/signup/screens/profile_image_setup_screen
 import 'package:ondo/presentation/auth/signup/screens/signup_complete_screen.dart';
 import 'package:ondo/presentation/auth/signup/screens/terms_agreement_screen.dart';
 import 'package:ondo/presentation/home/screens/home_screen.dart';
+import 'package:ondo/presentation/profile/screens/edit_profile_screen.dart';
+import 'package:ondo/presentation/profile/screens/my_profile_screen.dart';
+import 'package:ondo/presentation/profile/screens/other_profile_screen.dart';
+import 'package:ondo/presentation/profile/screens/setting_screen.dart';
+import 'package:ondo/presentation/profile/screens/terms_screen.dart';
 
 class RoutePaths {
   static const String home = '/';
   static const String login = '/login';
+
   static const String profile = '/profile';
+  static const String editProfile = '/profile/edit';
+  static const String profileSetting = '/profile/setting';
+  static const String profileTerms = '/profile/setting/terms';
+  static const String userProfile = 'user/profile';
 
   static const String signup = '/signup';
   static const String signupTerms = '/signup/terms';
@@ -40,7 +50,7 @@ class RoutePaths {
 }
 
 final GoRouter appRouter = GoRouter(
-  initialLocation: RoutePaths.home,
+  initialLocation: RoutePaths.profile,
   routes: [
     GoRoute(
       path: RoutePaths.home,
@@ -57,9 +67,31 @@ final GoRouter appRouter = GoRouter(
     GoRoute(
       path: RoutePaths.profile,
       name: 'profile',
-      builder: (context, state) => Scaffold(
-        body: Text('프로필'),
-      ),
+      builder: (context, state) => MyProfileScreen(),
+      routes: [
+        GoRoute(
+          path: 'edit',
+          name: 'editProfile',
+          builder: (context, state) => EditProfileScreen(),
+        ),
+        GoRoute(
+          path: 'setting',
+          name: 'profileSetting',
+          builder: (context, state) => SettingScreen(),
+          routes: [
+            GoRoute(
+              path: 'terms',
+              name: 'profileTerms',
+              builder: (context, state) => TermsScreen(),
+            ),
+          ],
+        ),
+        GoRoute(
+          path: RoutePaths.userProfile,
+          name: 'userProfile',
+          builder: (context, state) => OtherProfileScreen(),
+        ),
+      ],
     ), //profile
 
     GoRoute(
@@ -67,9 +99,10 @@ final GoRouter appRouter = GoRouter(
       name: 'signup',
       redirect: (context, state) {
         Get.lazyPut(() => SignupFlowController());
-        if(state.matchedLocation == RoutePaths.signup){
+        if (state.matchedLocation == RoutePaths.signup) {
           return RoutePaths.signupTerms;
-        }return null;
+        }
+        return null;
       },
       routes: [
         GoRoute(

--- a/lib/presentation/profile/screens/edit_profile_screen.dart
+++ b/lib/presentation/profile/screens/edit_profile_screen.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:ondo/core/design_system/app_layout.dart';
 import 'package:ondo/core/design_system/component_variants.dart';
 import 'package:ondo/core/design_system/components/custom_back_button.dart';
 import 'package:ondo/core/design_system/components/custom_button.dart';
 import 'package:ondo/core/design_system/components/custom_textfield.dart';
+import 'package:ondo/core/router/app_router.dart';
 import 'package:ondo/core/ui/base/base_scaffold.dart';
 import 'package:ondo/presentation/profile/widget/edit_profile/profile_image_section.dart';
 import 'package:ondo/presentation/profile/widget/edit_profile/profile_tag_section.dart';
@@ -76,7 +78,12 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
         body: Column(
           mainAxisAlignment: MainAxisAlignment.start,
           children: [
-            CustomBackButton(moreOptions: false),
+            GestureDetector(
+              onTap: () => context.pop(),
+              child: CustomBackButton(
+                moreOptions: false,
+              ),
+            ),
             Expanded(
               child: SingleChildScrollView(
                 child: Padding(
@@ -132,7 +139,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                 text: "변경 완료",
                 variant: ButtonVariant.primary,
                 onPressed: () {
-                  //context.push(RoutePaths.myProfile);
+                  context.push(RoutePaths.profile);
                 },
               ),
             ),

--- a/lib/presentation/profile/screens/my_profile_screen.dart
+++ b/lib/presentation/profile/screens/my_profile_screen.dart
@@ -1,11 +1,13 @@
 import 'dart:developer';
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:ondo/core/design_system/app_colors.dart';
 import 'package:ondo/core/design_system/app_layout.dart';
 import 'package:ondo/core/design_system/app_text_styles.dart';
 import 'package:ondo/core/design_system/components/custom_popup_menu_button.dart';
 import 'package:ondo/core/design_system/components/post/post_item.dart';
+import 'package:ondo/core/router/app_router.dart';
 import 'package:ondo/core/ui/base/base_scaffold.dart';
 import 'package:ondo/presentation/profile/widget/profile_activity_section.dart';
 import 'package:ondo/presentation/profile/widget/profile_indicator_post_page_list.dart';
@@ -15,15 +17,6 @@ import 'package:ondo/presentation/profile/widget/user_introduction_text.dart';
 import 'package:ondo/presentation/profile/widget/user_logout_popup.dart';
 import 'package:ondo/presentation/profile/widget/user_name_and_major.dart';
 import 'package:ondo/presentation/profile/widget/user_profile_image.dart';
-
-void main() {
-  runApp(
-    MaterialApp(
-      debugShowCheckedModeBanner: false,
-      home: MyProfileScreen(),
-    ),
-  );
-}
 
 final List<Map<String, dynamic>> mockPostData = [
   {
@@ -272,7 +265,10 @@ class MyProfileScreen extends StatelessWidget {
     return CustomPopupMenuButton(
       itemBuilder: (context) => [
         PopupMenuItem(
-          onTap: () => log("정보 수정하기"),
+          onTap: () {
+            log("정보 수정하기");
+            context.push(RoutePaths.editProfile);
+          },
           padding: AppPadding.settingSession,
           child: Text(
             "정보 수정하기",
@@ -288,7 +284,10 @@ class MyProfileScreen extends StatelessWidget {
           ),
         ),
         PopupMenuItem(
-          onTap: () => log("설정"),
+          onTap: () {
+            log("설정");
+            context.push(RoutePaths.profileSetting);
+            },
           padding: AppPadding.settingSession,
           child: Text(
             "설정",
@@ -298,5 +297,4 @@ class MyProfileScreen extends StatelessWidget {
       ],
     );
   }
-
 }

--- a/lib/presentation/profile/screens/setting_screen.dart
+++ b/lib/presentation/profile/screens/setting_screen.dart
@@ -1,21 +1,13 @@
-import 'dart:developer';
-
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:ondo/core/design_system/app_layout.dart';
 import 'package:ondo/core/design_system/components/custom_back_button.dart';
+import 'package:ondo/core/router/app_router.dart';
 import 'package:ondo/core/ui/base/base_scaffold.dart';
 import 'package:ondo/presentation/profile/widget/build_app_version_session.dart';
 import 'package:ondo/presentation/profile/widget/build_custom_switch.dart';
 import 'package:ondo/presentation/profile/widget/custom_setting_item.dart';
 import 'package:ondo/presentation/profile/widget/user_delete_popup.dart';
-
-void main() {
-  runApp(
-    MaterialApp(
-      home: SettingScreen(),
-    ),
-  );
-}
 
 class SettingScreen extends StatefulWidget {
   const SettingScreen({super.key});
@@ -38,7 +30,10 @@ class _SettingScreenState extends State<SettingScreen> {
         body: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            CustomBackButton(moreOptions: false),
+            GestureDetector(
+              onTap: () => context.pushReplacement(RoutePaths.profile),
+              child: CustomBackButton(moreOptions: false),
+            ),
             AppGap.v16,
             Container(
               width: MediaQuery.of(context).size.width,
@@ -92,7 +87,7 @@ class _SettingScreenState extends State<SettingScreen> {
                 children: [
                   CustomSettingItem(
                     name: "이용약관",
-                    onTap: () => log('이용약관'),
+                    onTap: () => context.push(RoutePaths.profileTerms),
                   ),
                   AppGap.v24,
                   CustomSettingItem(

--- a/lib/presentation/profile/screens/setting_screen.dart
+++ b/lib/presentation/profile/screens/setting_screen.dart
@@ -31,7 +31,7 @@ class _SettingScreenState extends State<SettingScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             GestureDetector(
-              onTap: () => context.pushReplacement(RoutePaths.profile),
+              onTap: () => context.pop(),
               child: CustomBackButton(moreOptions: false),
             ),
             AppGap.v16,

--- a/lib/presentation/profile/screens/terms_screen.dart
+++ b/lib/presentation/profile/screens/terms_screen.dart
@@ -1,18 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:ondo/core/design_system/app_colors.dart';
 import 'package:ondo/core/design_system/app_layout.dart';
 import 'package:ondo/core/design_system/app_strings.dart';
 import 'package:ondo/core/design_system/app_text_styles.dart';
 import 'package:ondo/core/design_system/components/custom_back_button.dart';
+import 'package:ondo/core/router/app_router.dart';
 import 'package:ondo/core/ui/base/base_scaffold.dart';
-
-void main() {
-  runApp(
-    MaterialApp(
-      home: TermsScreen(),
-    ),
-  );
-}
 
 class TermsScreen extends StatelessWidget {
   const TermsScreen({super.key});
@@ -25,7 +19,10 @@ class TermsScreen extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            CustomBackButton(moreOptions: false),
+            GestureDetector(
+              onTap: () => context.pushReplacement(RoutePaths.profileSetting),
+              child: CustomBackButton(moreOptions: false),
+            ),
             AppGap.v16,
             Container(
               margin: AppPadding.terms,

--- a/lib/presentation/profile/screens/terms_screen.dart
+++ b/lib/presentation/profile/screens/terms_screen.dart
@@ -20,7 +20,7 @@ class TermsScreen extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             GestureDetector(
-              onTap: () => context.pushReplacement(RoutePaths.profileSetting),
+              onTap: () => context.pop(),
               child: CustomBackButton(moreOptions: false),
             ),
             AppGap.v16,

--- a/lib/presentation/profile/screens/terms_screen.dart
+++ b/lib/presentation/profile/screens/terms_screen.dart
@@ -5,7 +5,6 @@ import 'package:ondo/core/design_system/app_layout.dart';
 import 'package:ondo/core/design_system/app_strings.dart';
 import 'package:ondo/core/design_system/app_text_styles.dart';
 import 'package:ondo/core/design_system/components/custom_back_button.dart';
-import 'package:ondo/core/router/app_router.dart';
 import 'package:ondo/core/ui/base/base_scaffold.dart';
 
 class TermsScreen extends StatelessWidget {


### PR DESCRIPTION
## 📌 개요

프로필 도메인(마이 프로필, 프로필 수정, 설정, 이용약관)의
go_router 기반 라우팅 구조를 설계하고 각 화면에 네비게이션을 적용했습니다.

---

## 🧩 작업 내용

* [x] `/profile` → 마이 프로필 연결
* [x] `/profile/edit` → 프로필 수정 연결
* [x] `/profile/setting` → 설정 페이지 연결
* [x] `/profile/setting/terms` → 이용약관 페이지 연결
* [x] 상대 프로필 라우트 기본 구조 추가 (UI 미적용)
* [x] 각 화면에서 `context.push()` 기반 네비게이션 적용

---

## 📎 참고 사항

* 상대 프로필 화면은 현재 UI 미완성 상태로 라우트만 정의되어 있음
* 기존 구조에서 redirect-only route 문제 해결
* `MaterialApp.router` 기반 구조 정상 동작 확인 완료

---

close: #80 
