### PR TITLE
[FEATURE] NavigationScreen 및 하단 네비게이션 바 구현

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:get/get_core/src/get_main.dart';
-import 'package:get/get_instance/src/bindings_interface.dart';
-import 'package:get/get_instance/src/extension_instance.dart';
+import 'package:get/get.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ondo/presentation/auth/signup/controllers/email_code_input_controller.dart';
 import 'package:ondo/presentation/auth/signup/controllers/email_input_controller.dart';
@@ -22,6 +20,8 @@ import 'package:ondo/presentation/auth/signup/screens/profile_image_setup_screen
 import 'package:ondo/presentation/auth/signup/screens/signup_complete_screen.dart';
 import 'package:ondo/presentation/auth/signup/screens/terms_agreement_screen.dart';
 import 'package:ondo/presentation/home/screens/home_screen.dart';
+import 'package:ondo/presentation/navigation/controllers/navigation_controller.dart';
+import 'package:ondo/presentation/navigation/screens/navigation_screen.dart';
 import 'package:ondo/presentation/profile/screens/edit_profile_screen.dart';
 import 'package:ondo/presentation/profile/screens/my_profile_screen.dart';
 import 'package:ondo/presentation/profile/screens/other_profile_screen.dart';
@@ -29,7 +29,9 @@ import 'package:ondo/presentation/profile/screens/setting_screen.dart';
 import 'package:ondo/presentation/profile/screens/terms_screen.dart';
 
 class RoutePaths {
-  static const String home = '/';
+  static const String navigation = '/';
+
+  static const String home = '/home';
   static const String login = '/login';
 
   static const String profile = '/profile';
@@ -51,8 +53,17 @@ class RoutePaths {
 }
 
 final GoRouter appRouter = GoRouter(
-  initialLocation: RoutePaths.profile,
+  initialLocation: RoutePaths.navigation,
   routes: [
+    GoRoute(
+      path: RoutePaths.navigation,
+      name: 'navigation',
+      builder: (context, state) {
+        Get.put(NavigationController());
+        return NavigationScreen();
+      },
+    ),
+
     GoRoute(
       path: RoutePaths.home,
       name: 'home',

--- a/lib/presentation/navigation/controllers/navigation_controller.dart
+++ b/lib/presentation/navigation/controllers/navigation_controller.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/cupertino.dart';
+import 'package:get/get.dart';
+
+class NavigationController extends GetxController {
+  final RxInt currentIndex = 0.obs;
+  final PageController pageController = PageController();
+
+  void changeIndex(int index) {
+    currentIndex.value = index;
+    pageController.animateToPage(
+      index,
+      duration: Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  void onPageChange(int index){
+    currentIndex.value = index;
+  }
+
+  @override
+  void onClose(){
+    pageController.dispose();
+    super.onClose();
+  }
+}

--- a/lib/presentation/navigation/screens/navigation_screen.dart
+++ b/lib/presentation/navigation/screens/navigation_screen.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:get/get.dart';
+import 'package:ondo/core/design_system/app_colors.dart';
+import 'package:ondo/core/design_system/app_icon.dart';
+import 'package:ondo/core/design_system/app_text_styles.dart';
+import 'package:ondo/presentation/chat/screens/chat_main_screen.dart';
+import 'package:ondo/presentation/community/screens/community_main_screen.dart';
+import 'package:ondo/presentation/home/screens/home_screen.dart';
+import 'package:ondo/presentation/navigation/controllers/navigation_controller.dart';
+import 'package:ondo/presentation/profile/screens/my_profile_screen.dart';
+
+class NavigationScreen extends GetView<NavigationController> {
+  const NavigationScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    List<Widget> pageList = [
+      HomeScreen(),
+      CommunityMainScreen(),
+      ChatMainScreen(),
+      MyProfileScreen(),
+    ];
+
+    return Obx(
+      () => Scaffold(
+        body: PageView(
+          controller: controller.pageController,
+          onPageChanged: controller.onPageChange,
+          children: pageList,
+        ),
+        bottomNavigationBar: _buildBottomNavigationBar(context, controller),
+      ),
+    );
+  }
+
+  Widget _buildBottomNavigationBar(
+    BuildContext context,
+    NavigationController controller,
+  ) {
+    return BottomNavigationBar(
+      currentIndex: controller.currentIndex.value,
+      onTap: (value) {
+        controller.changeIndex(value);
+      },
+      type: BottomNavigationBarType.fixed,
+      selectedItemColor: AppColors.primary,
+      selectedLabelStyle: AppTextStyles.caption(textColor: AppColors.primary),
+      unselectedItemColor: AppColors.gray50,
+      unselectedLabelStyle: AppTextStyles.caption(textColor: AppColors.gray50),
+      backgroundColor: AppColors.white,
+      elevation: 0,
+      items: [
+        BottomNavigationBarItem(
+          icon: SvgPicture.asset(AppIcon.homeUnSelect.path),
+          activeIcon: SvgPicture.asset(AppIcon.homeSelect.path),
+          label: '홈',
+        ),
+        BottomNavigationBarItem(
+          icon: SvgPicture.asset(AppIcon.communityUnSelect.path),
+          activeIcon: SvgPicture.asset(AppIcon.communitySelect.path),
+          label: '커뮤니티',
+        ),
+        BottomNavigationBarItem(
+          icon: SvgPicture.asset(AppIcon.chatUnSelect.path),
+          activeIcon: SvgPicture.asset(AppIcon.chatSelect.path),
+          label: '채팅',
+        ),
+        BottomNavigationBarItem(
+          icon: SvgPicture.asset(AppIcon.userUnSelect.path),
+          activeIcon: SvgPicture.asset(AppIcon.userSelect.path),
+          label: '프로필',
+        ),
+      ],
+    );
+  }
+}
+
+class TestCommunity extends StatelessWidget {
+  const TestCommunity({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(body: Center(child: Text("community")));
+  }
+}

--- a/lib/presentation/navigation/screens/navigation_screen.dart
+++ b/lib/presentation/navigation/screens/navigation_screen.dart
@@ -75,12 +75,3 @@ class NavigationScreen extends GetView<NavigationController> {
     );
   }
 }
-
-class TestCommunity extends StatelessWidget {
-  const TestCommunity({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(body: Center(child: Text("community")));
-  }
-}

--- a/lib/presentation/profile/screens/edit_profile_screen.dart
+++ b/lib/presentation/profile/screens/edit_profile_screen.dart
@@ -5,7 +5,6 @@ import 'package:ondo/core/design_system/component_variants.dart';
 import 'package:ondo/core/design_system/components/custom_back_button.dart';
 import 'package:ondo/core/design_system/components/custom_button.dart';
 import 'package:ondo/core/design_system/components/custom_textfield.dart';
-import 'package:ondo/core/router/app_router.dart';
 import 'package:ondo/core/ui/base/base_scaffold.dart';
 import 'package:ondo/presentation/profile/widget/edit_profile/profile_image_section.dart';
 import 'package:ondo/presentation/profile/widget/edit_profile/profile_tag_section.dart';
@@ -139,7 +138,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                 text: "변경 완료",
                 variant: ButtonVariant.primary,
                 onPressed: () {
-                  context.push(RoutePaths.profile);
+                  context.pop();
                 },
               ),
             ),


### PR DESCRIPTION
## 📌 개요

> 하단 네비게이션(PageView 기반) 구조를 도입하고  
> 프로필 수정 이후에도 네비게이션 바가 유지되도록 동선을 개선했습니다.

---

## 🧩 작업 내용

- [x] app_router.dart에 navigation 루트 추가
- [x] NavigationController 생성 (PageView 상태 관리)
- [x] NavigationScreen 생성 (BottomNavigationBar + PageView 적용)
- [x] EditProfileScreen 이동 로직 수정 (pop 처리로 Navigation 유지)

---

## 📎 참고 사항

- PageView 기반 탭 전환 구조 적용
- 프로필 수정 완료 시 push → pop 방식으로 변경
- NavigationScreen이 루트로 동작하도록 라우팅 구조 정리

close #84 