### PR TITLE
[FEATURE] 커뮤티니 게시물 상세 페이지 퍼블리싱

### DIFF
--- a/lib/core/design_system/app_layout.dart
+++ b/lib/core/design_system/app_layout.dart
@@ -15,6 +15,7 @@ class AppSpacing {
   static const double s18 = 18;
   static const double s24 = 24;
   static const double s28 = 28;
+  static const double s32 = 32;
   static const double s36 = 36;
   static const double s40 = 40;
   static const double s42 = 42;

--- a/lib/core/design_system/app_text_styles.dart
+++ b/lib/core/design_system/app_text_styles.dart
@@ -96,7 +96,7 @@ class AppTextStyles {
     );
   }
 
-  static TextStyle popupTitle({
+  static TextStyle titleBold20({
     Color? textColor,
   }) {
     return TextStyle(

--- a/lib/core/design_system/components/custom_alert_dialog.dart
+++ b/lib/core/design_system/components/custom_alert_dialog.dart
@@ -36,7 +36,7 @@ class CustomAlertDialog extends StatelessWidget {
           children: [
             Text(
               title,
-              style: AppTextStyles.popupTitle(),
+              style: AppTextStyles.titleBold20(),
             ),
             AppGap.v24,
             Text(

--- a/lib/core/design_system/components/custom_confirm_popup.dart
+++ b/lib/core/design_system/components/custom_confirm_popup.dart
@@ -39,7 +39,7 @@ class CustomConfirmPopup extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            Center(child: Text(title, style: AppTextStyles.popupTitle())),
+            Center(child: Text(title, style: AppTextStyles.titleBold20())),
             AppGap.v24,
             Center(
               child: Text(

--- a/lib/core/design_system/components/custom_profile_circle.dart
+++ b/lib/core/design_system/components/custom_profile_circle.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:ondo/core/design_system/app_icon.dart';
+import 'package:ondo/core/design_system/app_layout.dart';
+
+class CustomProfileCircle extends StatelessWidget {
+  const CustomProfileCircle({super.key, required this.radius, this.imageUrl})
+    : hasImage = imageUrl != null;
+
+  final double radius;
+  final String? imageUrl;
+  final bool hasImage;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: radius,
+      height: radius,
+      decoration: BoxDecoration(
+        borderRadius: AppRadius.circleRadius,
+        image: hasImage
+            ? DecorationImage(image: NetworkImage(imageUrl!), fit: BoxFit.cover)
+            : null,
+      ),
+      child: !hasImage
+          ? SvgPicture.asset(
+              AppIcon.defaultProfile.path,
+              fit: BoxFit.cover,
+            )
+          : null,
+    );
+  }
+}

--- a/lib/core/design_system/components/custom_profile_circle.dart
+++ b/lib/core/design_system/components/custom_profile_circle.dart
@@ -18,16 +18,19 @@ class CustomProfileCircle extends StatelessWidget {
       height: radius,
       decoration: BoxDecoration(
         borderRadius: AppRadius.circleRadius,
-        image: hasImage
-            ? DecorationImage(image: NetworkImage(imageUrl!), fit: BoxFit.cover)
-            : null,
       ),
-      child: !hasImage
-          ? SvgPicture.asset(
-              AppIcon.defaultProfile.path,
+      child: hasImage
+          ? Image.network(
+              imageUrl!,
               fit: BoxFit.cover,
+              errorBuilder: (context, error, stackTrace) => _defaultImage(),
             )
-          : null,
+          : _defaultImage(),
     );
   }
+
+  Widget _defaultImage() => SvgPicture.asset(
+    AppIcon.defaultProfile.path,
+    fit: BoxFit.cover,
+  );
 }

--- a/lib/presentation/auth/signup/screens/nickname_setup_screen.dart
+++ b/lib/presentation/auth/signup/screens/nickname_setup_screen.dart
@@ -18,9 +18,10 @@ class NicknameSetupScreen extends StatefulWidget {
   State<NicknameSetupScreen> createState() => _NicknameSetupScreenState();
 }
 
-TextEditingController controller = TextEditingController();
-
 class _NicknameSetupScreenState extends State<NicknameSetupScreen> {
+
+  TextEditingController controller = TextEditingController();
+
   @override
   Widget build(BuildContext context) {
     return SafeArea(

--- a/lib/presentation/chat/widgets/chat_review_dialog.dart
+++ b/lib/presentation/chat/widgets/chat_review_dialog.dart
@@ -77,7 +77,7 @@ class _ChatReviewDialogState extends State<ChatReviewDialog> {
           children: [
             Text(
               "리뷰 남기기",
-              style: AppTextStyles.popupTitle(),
+              style: AppTextStyles.titleBold20(),
             ),
             AppGap.v16,
             _starIconList(),

--- a/lib/presentation/community/controllers/post_view_controller.dart
+++ b/lib/presentation/community/controllers/post_view_controller.dart
@@ -1,0 +1,12 @@
+import 'package:get/get.dart';
+
+class PostViewController extends GetxController {
+  RxString title = "".obs;
+  RxString authorName = "김유찬".obs;
+  Rx<Duration> postAt = Duration(minutes: 4).obs;
+  RxBool selectHeart = false.obs;
+  RxBool selectBookMark = false.obs;
+  RxList<String> postTags = <String>[].obs;
+  RxString bodyText = "".obs;
+  RxList<String> comments = <String>[].obs;
+}

--- a/lib/presentation/community/controllers/post_view_controller.dart
+++ b/lib/presentation/community/controllers/post_view_controller.dart
@@ -27,6 +27,10 @@ class PostViewController extends GetxController {
 
     super.onInit();
   }
+
+  void deletePostRequest () {}
+
+
 }
 
 extension DummyData on PostViewController {

--- a/lib/presentation/community/controllers/post_view_controller.dart
+++ b/lib/presentation/community/controllers/post_view_controller.dart
@@ -2,11 +2,79 @@ import 'package:get/get.dart';
 
 class PostViewController extends GetxController {
   RxString title = "".obs;
-  RxString authorName = "김유찬".obs;
-  Rx<Duration> postAt = Duration(minutes: 4).obs;
-  RxBool selectHeart = false.obs;
-  RxBool selectBookMark = false.obs;
+  RxString authorName = "".obs;
+  Rx<Duration> postAt = Duration().obs;
+  bool selectHeart = false;
+  bool selectBookMark = false;
+  int heartTotal = 0;
+  int bookMarkTotal = 0;
   RxList<String> postTags = <String>[].obs;
   RxString bodyText = "".obs;
-  RxList<String> comments = <String>[].obs;
+  RxList<Comment> comments = <Comment>[].obs;
+
+  @override
+  void onInit() {
+    title.value = getTitle();
+    authorName.value = getAuthor();
+    postAt.value = getPostAt();
+    selectHeart = getSelectHeart();
+    selectBookMark = getSelectBookMark();
+    heartTotal = getHeartTotal();
+    bookMarkTotal = getBookMarkTotal();
+    postTags.value = getPostTags();
+    bodyText.value = getBodyText();
+    comments.value = getComments();
+
+    super.onInit();
+  }
 }
+
+extension DummyData on PostViewController {
+  String getTitle() => "요즘 UI UX";
+
+  String getAuthor() => "김유찬";
+
+  Duration getPostAt() => Duration(minutes: 4);
+
+  bool getSelectHeart() => false;
+  bool getSelectBookMark() => true;
+  int getHeartTotal() => 12;
+  int getBookMarkTotal() => 12;
+
+  List<String> getPostTags() => ["#UI/UX", "#FrontEnd"];
+
+  String getBodyText() => """요즘 UI·UX 이슈 보면, 기술은 엄청 발전했는데 사용자 입장은 좀 
+애매해짐. AI 추천이니 자동 생성이니 많아졌는데, 솔직히 왜 그게 뜨는지 모르겠음. 내가 선택한 건지, 그냥 떠밀린 건지 경계가 흐려짐.
+
+개인화도 마찬가지임. 처음엔 편한데 쓰다 보면 피곤함. 설정 건드릴 
+여지도 없고, 앱이 “너 이거 좋아하잖아” 하고 단정 짓는 느낌 듦. 다크 
+패턴은 말할 것도 없고, 가입은 한 번에 되는데 탈퇴는 왜 이렇게 
+숨겨놓는지 아직도 이해 안 감.
+
+접근성도 형식만 맞춘 경우 많음. 체크리스트는 통과했는데 실제로 써보면 불편함. 애니메이션, 효과 잔뜩 넣은 UI도 처음엔 와 소리 나오는데, 정보 찾으려면 오히려 방해됨.
+
+결국 요즘 UX 문제는 기술 부족이 아니라 태도 문제 같음. 사용자를 배려한다면서 사실은 컨트롤하려는 설계. 이제는 “얼마나 오래 쓰게 만드나” 말고 “얼마나 덜 스트레스 받게 하나”로 가야 하지 않나 싶음.""";
+
+  List<Comment> getComments() => [
+    for (int i = 0; i < 3; i++) ...{
+      (
+        author: "김유찬",
+        heartTotal: 12,
+        conment: "ㄹㅇ 다크 패턴은 진짜 법으로 좀 쳐야 함… 탈퇴 버튼 숨겨놓는 거 볼 때마다 정 떨어짐.",
+      ),
+      (author: "김유찬", heartTotal: 12, conment: "UI 피로도가 ㄹㅈㄷ 도대체 왜 숨기는겨"),
+      (
+        author: "김유찬",
+        heartTotal: 16,
+        conment: "ㄹㅇ 다크 패턴은 진짜 법으로 좀 쳐야 함… 탈퇴 버튼 숨겨놓는 거 볼 때마다 정 떨어짐.",
+      ),
+      (
+        author: "김유찬",
+        heartTotal: 12,
+        conment: "진짜 ㄹㅇ 계정 탈퇴 한번 하려면 이거하고 저거하고 귀찮아 죽겠음 진짜",
+      ),
+    },
+  ];
+}
+
+typedef Comment = ({String author, String conment, int heartTotal});

--- a/lib/presentation/community/controllers/post_view_controller.dart
+++ b/lib/presentation/community/controllers/post_view_controller.dart
@@ -64,21 +64,21 @@ extension DummyData on PostViewController {
       (
         author: "김유찬",
         heartTotal: 12,
-        conment: "ㄹㅇ 다크 패턴은 진짜 법으로 좀 쳐야 함… 탈퇴 버튼 숨겨놓는 거 볼 때마다 정 떨어짐.",
+        comment: "ㄹㅇ 다크 패턴은 진짜 법으로 좀 쳐야 함… 탈퇴 버튼 숨겨놓는 거 볼 때마다 정 떨어짐.",
       ),
-      (author: "김유찬", heartTotal: 12, conment: "UI 피로도가 ㄹㅈㄷ 도대체 왜 숨기는겨"),
+      (author: "김유찬", heartTotal: 12, comment: "UI 피로도가 ㄹㅈㄷ 도대체 왜 숨기는겨"),
       (
         author: "김유찬",
         heartTotal: 16,
-        conment: "ㄹㅇ 다크 패턴은 진짜 법으로 좀 쳐야 함… 탈퇴 버튼 숨겨놓는 거 볼 때마다 정 떨어짐.",
+        comment: "ㄹㅇ 다크 패턴은 진짜 법으로 좀 쳐야 함… 탈퇴 버튼 숨겨놓는 거 볼 때마다 정 떨어짐.",
       ),
       (
         author: "김유찬",
         heartTotal: 12,
-        conment: "진짜 ㄹㅇ 계정 탈퇴 한번 하려면 이거하고 저거하고 귀찮아 죽겠음 진짜",
+        comment: "진짜 ㄹㅇ 계정 탈퇴 한번 하려면 이거하고 저거하고 귀찮아 죽겠음 진짜",
       ),
     },
   ];
 }
 
-typedef Comment = ({String author, String conment, int heartTotal});
+typedef Comment = ({String author, String comment, int heartTotal});

--- a/lib/presentation/community/screens/community_post_detail_screen.dart
+++ b/lib/presentation/community/screens/community_post_detail_screen.dart
@@ -40,12 +40,6 @@ class _CommunityPostDetailScreenState extends State<CommunityPostDetailScreen> {
     super.initState();
   }
 
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
   void _showPostReportDialog() {
     showDialog(
       context: context,
@@ -78,7 +72,7 @@ class _CommunityPostDetailScreenState extends State<CommunityPostDetailScreen> {
             ..._top(),
             AppGap.v16,
             _body(),
-            footer(),
+            _footer(),
           ],
         ),
       ),
@@ -111,7 +105,7 @@ class _CommunityPostDetailScreenState extends State<CommunityPostDetailScreen> {
     ),
   );
 
-  Widget footer() => Container(
+  Widget _footer() => Container(
     color: AppColors.background,
     padding: AppPadding.screenHorizontal,
     child: Column(
@@ -263,6 +257,7 @@ class _CommentListState extends State<_CommentList> {
           Expanded(
             child: Obx(
               () => PageView.builder(
+                controller: _pageController,
                 onPageChanged: (value) {
                   curIndex.value = value;
                 },
@@ -283,7 +278,11 @@ class _CommentListState extends State<_CommentList> {
               currentPage: value,
               totalPage: _getTotalPage(),
               onTap: (value) {
-                _pageController.jumpToPage(value);
+                _pageController.animateToPage(
+                  value,
+                  duration: Duration(milliseconds: 300),
+                  curve: Curves.ease,
+                );
               },
             ),
           ),
@@ -312,7 +311,7 @@ class _CommentListState extends State<_CommentList> {
         ...subComments.map(
           (comment) => CommunityPostCommentCard(
             author: comment.author,
-            commentText: comment.conment,
+            commentText: comment.comment,
             heartTotal: comment.heartTotal,
           ),
         ),

--- a/lib/presentation/community/screens/community_post_detail_screen.dart
+++ b/lib/presentation/community/screens/community_post_detail_screen.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:ondo/core/design_system/app_colors.dart';
+import 'package:ondo/core/design_system/app_icon.dart';
+import 'package:ondo/core/design_system/app_layout.dart';
+import 'package:ondo/core/design_system/app_text_styles.dart';
+import 'package:ondo/core/design_system/components/custom_back_button.dart';
+import 'package:ondo/core/design_system/components/custom_profile_circle.dart';
+import 'package:ondo/core/ui/base/base_scaffold.dart';
+import 'package:ondo/presentation/community/controllers/post_view_controller.dart';
+import 'package:ondo/presentation/community/widgets/community_custom_icon_button.dart';
+
+
+class CommunityPostDetailScreen extends StatefulWidget {
+  const CommunityPostDetailScreen.myPost({super.key}) : isMy = true;
+
+  const CommunityPostDetailScreen.otherPost({super.key}) : isMy = false;
+
+  final bool isMy;
+
+  @override
+  State<CommunityPostDetailScreen> createState() =>
+      _CommunityPostDetailScreenState();
+}
+
+class _CommunityPostDetailScreenState extends State<CommunityPostDetailScreen> {
+  @override
+  void initState() {
+    Get.put(PostViewController());
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      body: Column(
+        children: [..._top(), AppGap.v16, _body()],
+      ),
+    );
+  }
+
+  List<Widget> _top() => [
+    CustomBackButton(
+      moreOptions: true,
+      itemBuilder: (context) => [
+        if (!widget.isMy)
+          _topPopupItem("게시물 신고하기")
+        else ...[
+          _topPopupItem("게시물 수정하기"),
+          _topPopupItem("게시물 삭제하기"),
+        ],
+      ],
+    ),
+    _Title(title: "요즘 UI UX", tags: ["#UI/UX", "#FrontEnd"]),
+  ];
+
+  Widget _body() => Padding(
+    padding: AppPadding.screenHorizontal,
+    child: Column(
+      children: [
+        _Body(),
+      ],
+    ),
+  );
+
+  PopupMenuEntry<String> _topPopupItem(String title) => PopupMenuItem(
+    padding: AppPadding.popupManuButton,
+    child: Center(child: Text(title)),
+  );
+}
+
+class _Title extends StatelessWidget {
+  const _Title({required this.title, required this.tags});
+
+  final String title;
+  final List<String> tags;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: AppPadding.screenHorizontal,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: AppTextStyles.titleBold20(textColor: AppColors.gray90),
+          ),
+          AppGap.v16,
+          Row(
+            spacing: AppSpacing.s16,
+            children: tags
+                .map(
+                  (tag) => Text(
+                    tag,
+                    style: AppTextStyles.caption(textColor: AppColors.gray60),
+                  ),
+                )
+                .toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  _Body();
+
+  final String author = "김유찬";
+  final Duration postAt = Duration(minutes: 4);
+  final String bodyText = """요즘 UI·UX 이슈 보면, 기술은 엄청 발전했는데 사용자 입장은 좀 
+애매해짐. AI 추천이니 자동 생성이니 많아졌는데, 솔직히 왜 그게 뜨는지 모르겠음. 내가 선택한 건지, 그냥 떠밀린 건지 경계가 흐려짐.
+
+개인화도 마찬가지임. 처음엔 편한데 쓰다 보면 피곤함. 설정 건드릴 
+여지도 없고, 앱이 “너 이거 좋아하잖아” 하고 단정 짓는 느낌 듦. 다크 
+패턴은 말할 것도 없고, 가입은 한 번에 되는데 탈퇴는 왜 이렇게 
+숨겨놓는지 아직도 이해 안 감.
+
+접근성도 형식만 맞춘 경우 많음. 체크리스트는 통과했는데 실제로 써보면 불편함. 애니메이션, 효과 잔뜩 넣은 UI도 처음엔 와 소리 나오는데, 정보 찾으려면 오히려 방해됨.
+
+결국 요즘 UX 문제는 기술 부족이 아니라 태도 문제 같음. 사용자를 배려한다면서 사실은 컨트롤하려는 설계. 이제는 “얼마나 오래 쓰게 만드나” 말고 “얼마나 덜 스트레스 받게 하나”로 가야 하지 않나 싶음.""";
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _top(),
+        AppGap.v16,
+        _content(),
+        AppGap.v16,
+        _buttonList(),
+      ],
+    );
+  }
+
+  Widget _top() => DefaultTextStyle(
+    style: AppTextStyles.caption(textColor: AppColors.gray60),
+    child: Row(
+      children: [
+        CustomProfileCircle(radius: AppSpacing.s24),
+        AppGap.h12,
+        Expanded(child: Text(author)),
+        Text("${postAt.inMinutes}분전"),
+      ],
+    ),
+  );
+
+  Widget _content() => Text(
+    bodyText,
+    style: AppTextStyles.textMedium(textColor: AppColors.gray90),
+    textAlign: .start,
+  );
+
+  Widget _buttonList() => Row(
+    spacing: AppSpacing.s16,
+    children: [
+      CommunityCustomIconButton(
+        imagePath: AppIcon.heart.path,
+        action: (isSelect, total) {},
+        activeColor: AppColors.red,
+        total: 12,
+      ),
+      CommunityCustomIconButton(
+        imagePath: AppIcon.bookmark.path,
+        action: (isSelect, total) {},
+        activeColor: AppColors.yellow,
+        total: 12,
+        initialSelect: true,
+      ),
+    ],
+  );
+}

--- a/lib/presentation/community/screens/community_post_detail_screen.dart
+++ b/lib/presentation/community/screens/community_post_detail_screen.dart
@@ -6,6 +6,7 @@ import 'package:ondo/core/design_system/app_colors.dart';
 import 'package:ondo/core/design_system/app_icon.dart';
 import 'package:ondo/core/design_system/app_layout.dart';
 import 'package:ondo/core/design_system/app_text_styles.dart';
+import 'package:ondo/core/design_system/components/custom_alert_dialog.dart';
 import 'package:ondo/core/design_system/components/custom_back_button.dart';
 import 'package:ondo/core/design_system/components/custom_profile_circle.dart';
 import 'package:ondo/core/design_system/components/post/indicator_post_page_list.dart';
@@ -15,6 +16,7 @@ import 'package:ondo/core/ui/base/base_scaffold.dart';
 import 'package:ondo/presentation/community/controllers/post_view_controller.dart';
 import 'package:ondo/presentation/community/widgets/community_custom_icon_button.dart';
 import 'package:ondo/presentation/community/widgets/community_post_comment_card.dart';
+import 'package:ondo/presentation/community/widgets/community_post_report_dialog.dart';
 
 
 class CommunityPostDetailScreen extends StatefulWidget {
@@ -30,10 +32,41 @@ class CommunityPostDetailScreen extends StatefulWidget {
 }
 
 class _CommunityPostDetailScreenState extends State<CommunityPostDetailScreen> {
+  late final PostViewController _controller;
+
   @override
   void initState() {
-    Get.put(PostViewController());
+    _controller = Get.put(PostViewController());
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _showPostReportDialog() {
+    showDialog(
+      context: context,
+      builder: (context) => CommunityPostReportDialog(),
+    );
+  }
+
+  void _showDeletePostAlertDialog() {
+    showDialog(
+      context: context,
+      builder: (context) => CustomAlertDialog(
+        title: "알림",
+        comment: "정말 게시물 삭제하시겠어요?",
+        actionLeft: () => Navigator.pop(context),
+        actionRight: () {
+          _controller.deletePostRequest();
+          Navigator.pop(context);
+        },
+        rightActionText: "삭제",
+      ),
+    );
   }
 
   @override
@@ -57,10 +90,10 @@ class _CommunityPostDetailScreenState extends State<CommunityPostDetailScreen> {
       moreOptions: true,
       itemBuilder: (context) => [
         if (!widget.isMy)
-          _topPopupItem("게시물 신고하기")
+          _topPopupItem("게시물 신고하기", _showPostReportDialog)
         else ...[
-          _topPopupItem("게시물 수정하기"),
-          _topPopupItem("게시물 삭제하기"),
+          _topPopupItem("게시물 수정하기", () {}),
+          _topPopupItem("게시물 삭제하기", _showDeletePostAlertDialog),
         ],
       ],
     ),
@@ -89,10 +122,12 @@ class _CommunityPostDetailScreenState extends State<CommunityPostDetailScreen> {
     ),
   );
 
-  PopupMenuEntry<String> _topPopupItem(String title) => PopupMenuItem(
-    padding: AppPadding.popupManuButton,
-    child: Center(child: Text(title)),
-  );
+  PopupMenuEntry<String> _topPopupItem(String title, VoidCallback onTap) =>
+      PopupMenuItem(
+        padding: AppPadding.popupManuButton,
+        onTap: onTap,
+        child: Center(child: Text(title)),
+      );
 }
 
 class _Title extends GetView<PostViewController> {

--- a/lib/presentation/community/screens/community_post_detail_screen.dart
+++ b/lib/presentation/community/screens/community_post_detail_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:ondo/core/design_system/app_colors.dart';
@@ -6,9 +8,13 @@ import 'package:ondo/core/design_system/app_layout.dart';
 import 'package:ondo/core/design_system/app_text_styles.dart';
 import 'package:ondo/core/design_system/components/custom_back_button.dart';
 import 'package:ondo/core/design_system/components/custom_profile_circle.dart';
+import 'package:ondo/core/design_system/components/post/indicator_post_page_list.dart';
+import 'package:ondo/core/design_system/components/post/post_item.dart';
+import 'package:ondo/core/design_system/components/post/post_list_indicator.dart';
 import 'package:ondo/core/ui/base/base_scaffold.dart';
 import 'package:ondo/presentation/community/controllers/post_view_controller.dart';
 import 'package:ondo/presentation/community/widgets/community_custom_icon_button.dart';
+import 'package:ondo/presentation/community/widgets/community_post_comment_card.dart';
 
 
 class CommunityPostDetailScreen extends StatefulWidget {
@@ -33,8 +39,15 @@ class _CommunityPostDetailScreenState extends State<CommunityPostDetailScreen> {
   @override
   Widget build(BuildContext context) {
     return BaseScaffold(
-      body: Column(
-        children: [..._top(), AppGap.v16, _body()],
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            ..._top(),
+            AppGap.v16,
+            _body(),
+            footer(),
+          ],
+        ),
       ),
     );
   }
@@ -51,7 +64,7 @@ class _CommunityPostDetailScreenState extends State<CommunityPostDetailScreen> {
         ],
       ],
     ),
-    _Title(title: "요즘 UI UX", tags: ["#UI/UX", "#FrontEnd"]),
+    _Title(),
   ];
 
   Widget _body() => Padding(
@@ -59,6 +72,19 @@ class _CommunityPostDetailScreenState extends State<CommunityPostDetailScreen> {
     child: Column(
       children: [
         _Body(),
+        AppGap.v24,
+        _CommentList(),
+      ],
+    ),
+  );
+
+  Widget footer() => Container(
+    color: AppColors.background,
+    padding: AppPadding.screenHorizontal,
+    child: Column(
+      children: [
+        AppGap.v16,
+        _RelatedPostList(),
       ],
     ),
   );
@@ -69,58 +95,42 @@ class _CommunityPostDetailScreenState extends State<CommunityPostDetailScreen> {
   );
 }
 
-class _Title extends StatelessWidget {
-  const _Title({required this.title, required this.tags});
-
-  final String title;
-  final List<String> tags;
-
+class _Title extends GetView<PostViewController> {
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: AppPadding.screenHorizontal,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            title,
-            style: AppTextStyles.titleBold20(textColor: AppColors.gray90),
-          ),
-          AppGap.v16,
-          Row(
-            spacing: AppSpacing.s16,
-            children: tags
-                .map(
-                  (tag) => Text(
-                    tag,
-                    style: AppTextStyles.caption(textColor: AppColors.gray60),
-                  ),
-                )
-                .toList(),
-          ),
-        ],
+      child: SizedBox(
+        width: double.infinity,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              controller.title.value,
+              style: AppTextStyles.titleBold20(textColor: AppColors.gray90),
+              overflow: TextOverflow.ellipsis,
+            ),
+            AppGap.v16,
+            Wrap(
+              spacing: AppSpacing.s16,
+              children: controller.postTags
+                  .map(
+                    (tag) => Text(
+                      tag,
+                      style: AppTextStyles.caption(textColor: AppColors.gray60),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  )
+                  .toList(),
+            ),
+          ],
+        ),
       ),
     );
   }
 }
 
-class _Body extends StatelessWidget {
-  _Body();
-
-  final String author = "김유찬";
-  final Duration postAt = Duration(minutes: 4);
-  final String bodyText = """요즘 UI·UX 이슈 보면, 기술은 엄청 발전했는데 사용자 입장은 좀 
-애매해짐. AI 추천이니 자동 생성이니 많아졌는데, 솔직히 왜 그게 뜨는지 모르겠음. 내가 선택한 건지, 그냥 떠밀린 건지 경계가 흐려짐.
-
-개인화도 마찬가지임. 처음엔 편한데 쓰다 보면 피곤함. 설정 건드릴 
-여지도 없고, 앱이 “너 이거 좋아하잖아” 하고 단정 짓는 느낌 듦. 다크 
-패턴은 말할 것도 없고, 가입은 한 번에 되는데 탈퇴는 왜 이렇게 
-숨겨놓는지 아직도 이해 안 감.
-
-접근성도 형식만 맞춘 경우 많음. 체크리스트는 통과했는데 실제로 써보면 불편함. 애니메이션, 효과 잔뜩 넣은 UI도 처음엔 와 소리 나오는데, 정보 찾으려면 오히려 방해됨.
-
-결국 요즘 UX 문제는 기술 부족이 아니라 태도 문제 같음. 사용자를 배려한다면서 사실은 컨트롤하려는 설계. 이제는 “얼마나 오래 쓰게 만드나” 말고 “얼마나 덜 스트레스 받게 하나”로 가야 하지 않나 싶음.""";
-
+class _Body extends GetView<PostViewController> {
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -140,14 +150,14 @@ class _Body extends StatelessWidget {
       children: [
         CustomProfileCircle(radius: AppSpacing.s24),
         AppGap.h12,
-        Expanded(child: Text(author)),
-        Text("${postAt.inMinutes}분전"),
+        Expanded(child: Text(controller.authorName.value)),
+        Text("${controller.postAt.value.inMinutes}분전"),
       ],
     ),
   );
 
   Widget _content() => Text(
-    bodyText,
+    controller.bodyText.value,
     style: AppTextStyles.textMedium(textColor: AppColors.gray90),
     textAlign: .start,
   );
@@ -157,17 +167,142 @@ class _Body extends StatelessWidget {
     children: [
       CommunityCustomIconButton(
         imagePath: AppIcon.heart.path,
-        action: (isSelect, total) {},
+        action: (isSelect, total) {
+          controller.selectHeart = isSelect;
+          controller.heartTotal = total;
+        },
         activeColor: AppColors.red,
-        total: 12,
+        total: controller.heartTotal,
+        initialIsSelected: controller.selectHeart,
       ),
       CommunityCustomIconButton(
         imagePath: AppIcon.bookmark.path,
-        action: (isSelect, total) {},
+        action: (isSelect, total) {
+          controller.selectBookMark = isSelect;
+          controller.bookMarkTotal = total;
+        },
         activeColor: AppColors.yellow,
-        total: 12,
-        initialSelect: true,
+        total: controller.bookMarkTotal,
+        initialIsSelected: controller.selectBookMark,
       ),
     ],
   );
+}
+
+class _CommentList extends StatefulWidget {
+  @override
+  State<_CommentList> createState() => _CommentListState();
+}
+
+class _CommentListState extends State<_CommentList> {
+  late final PageController _pageController;
+  final PostViewController _controller = Get.find<PostViewController>();
+
+  final ValueNotifier<int> curIndex = ValueNotifier(0);
+
+  @override
+  void initState() {
+    _pageController = PageController();
+    super.initState();
+  }
+
+  int _getStartIndex(int index) => index * 4;
+
+  int _getLastIndex(int index) =>
+      min(_getStartIndex(index) + 4, _controller.comments.length);
+
+  int _getTotalPage() => (_controller.comments.length / 4).ceil();
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        maxHeight: 360,
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _title(),
+          AppGap.v16,
+          Expanded(
+            child: Obx(
+              () => PageView.builder(
+                onPageChanged: (value) {
+                  curIndex.value = value;
+                },
+                itemCount: _getTotalPage(),
+                itemBuilder: (context, index) => Center(
+                  child: _commentView(
+                    _getStartIndex(index),
+                    _getLastIndex(index),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          AppGap.v16,
+          ValueListenableBuilder(
+            valueListenable: curIndex,
+            builder: (context, value, _) => PostListIndicator(
+              currentPage: value,
+              totalPage: _getTotalPage(),
+              onTap: (value) {
+                _pageController.jumpToPage(value);
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _title() => Row(
+    children: [
+      Text("댓글", style: AppTextStyles.titleSm16(textColor: AppColors.gray90)),
+      AppGap.h12,
+      Text(
+        "${_controller.comments.length}",
+        style: AppTextStyles.textMedium(textColor: AppColors.gray60),
+      ),
+    ],
+  );
+
+  Widget _commentView(int startIndex, int lastIndex) {
+    final subComments = _controller.comments.sublist(startIndex, lastIndex);
+    return Column(
+      spacing: AppSpacing.s16,
+      mainAxisAlignment: MainAxisAlignment.start,
+      children: [
+        ...subComments.map(
+          (comment) => CommunityPostCommentCard(
+            author: comment.author,
+            commentText: comment.conment,
+            heartTotal: comment.heartTotal,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _RelatedPostList extends StatelessWidget {
+  _RelatedPostList();
+
+  final List<PostItem> posts = List.generate(
+    32,
+    (index) => PostItem(
+      skills: ["UI/UX", "FrontEnd"],
+      title: "요즘 UI UX",
+      author: "김유찬",
+      bookmarks: 12,
+      favorites: 12,
+      createMinutes: 4,
+    ),
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return IndicatorPostPageList(title: "관련 게시물", items: posts);
+  }
 }

--- a/lib/presentation/community/widgets/community_custom_icon_button.dart
+++ b/lib/presentation/community/widgets/community_custom_icon_button.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:ondo/core/design_system/app_colors.dart';
+import 'package:ondo/core/design_system/app_layout.dart';
+import 'package:ondo/core/design_system/app_text_styles.dart';
+
+class CommunityCustomIconButton extends StatelessWidget {
+  CommunityCustomIconButton({
+    super.key,
+    required this.imagePath,
+    required int total,
+    bool? initialSelect,
+    required this.activeColor,
+    required this.action,
+  }) {
+    this.total = ValueNotifier(total);
+    isSelected = ValueNotifier(initialSelect ?? false);
+  }
+
+  final String imagePath;
+  late final ValueNotifier<int> total;
+  late final ValueNotifier<bool> isSelected;
+  final Color activeColor;
+  final void Function(bool isSelect, int total) action;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: Listenable.merge([isSelected, total]),
+      builder: (context, child) {
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            GestureDetector(
+              onTap: () {
+                isSelected.value = !isSelected.value;
+                isSelected.value ? total.value += 1 : total.value -= 1;
+                action.call(isSelected.value, total.value);
+              },
+              child: Image.asset(
+                imagePath,
+                color: isSelected.value ? activeColor : AppColors.gray50,
+                height: AppSpacing.s32,
+                width: AppSpacing.s32,
+              ),
+            ),
+            AppGap.h4,
+            Text(
+              "${total.value}",
+              style: AppTextStyles.textMedium(textColor: AppColors.gray50),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/community/widgets/community_custom_icon_button.dart
+++ b/lib/presentation/community/widgets/community_custom_icon_button.dart
@@ -47,7 +47,7 @@ class _CommunityCustomIconButtonState extends State<CommunityCustomIconButton> {
               isSelect = !isSelect;
               isSelect ? total += 1 : total -= 1;
             });
-            widget.action.call(widget.initialIsSelected, total);
+            widget.action.call(isSelect, total);
           },
           child: Image.asset(
             widget.imagePath,

--- a/lib/presentation/community/widgets/community_custom_icon_button.dart
+++ b/lib/presentation/community/widgets/community_custom_icon_button.dart
@@ -51,16 +51,14 @@ class _CommunityCustomIconButtonState extends State<CommunityCustomIconButton> {
           },
           child: Image.asset(
             widget.imagePath,
-            color: isSelect
-                ? widget.activeColor
-                : AppColors.gray50,
+            color: isSelect ? widget.activeColor : AppColors.gray50,
             height: AppSpacing.s32,
             width: AppSpacing.s32,
           ),
         ),
         AppGap.h4,
         Text(
-          "${total}",
+          "$total",
           style: AppTextStyles.textMedium(textColor: AppColors.gray50),
         ),
       ],

--- a/lib/presentation/community/widgets/community_custom_icon_button.dart
+++ b/lib/presentation/community/widgets/community_custom_icon_button.dart
@@ -3,54 +3,67 @@ import 'package:ondo/core/design_system/app_colors.dart';
 import 'package:ondo/core/design_system/app_layout.dart';
 import 'package:ondo/core/design_system/app_text_styles.dart';
 
-class CommunityCustomIconButton extends StatelessWidget {
-  CommunityCustomIconButton({
+class CommunityCustomIconButton extends StatefulWidget {
+  const CommunityCustomIconButton({
     super.key,
     required this.imagePath,
-    required int total,
-    bool? initialSelect,
+    required this.total,
     required this.activeColor,
     required this.action,
-  }) {
-    this.total = ValueNotifier(total);
-    isSelected = ValueNotifier(initialSelect ?? false);
-  }
+    this.initialIsSelected = false,
+  });
 
   final String imagePath;
-  late final ValueNotifier<int> total;
-  late final ValueNotifier<bool> isSelected;
+  final int total;
+  final bool initialIsSelected;
   final Color activeColor;
   final void Function(bool isSelect, int total) action;
 
   @override
+  State<CommunityCustomIconButton> createState() =>
+      _CommunityCustomIconButtonState();
+}
+
+class _CommunityCustomIconButtonState extends State<CommunityCustomIconButton> {
+  late int total;
+  late bool isSelect;
+
+  @override
+  void initState() {
+    total = widget.total;
+    isSelect = widget.initialIsSelected;
+
+    super.initState();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: Listenable.merge([isSelected, total]),
-      builder: (context, child) {
-        return Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            GestureDetector(
-              onTap: () {
-                isSelected.value = !isSelected.value;
-                isSelected.value ? total.value += 1 : total.value -= 1;
-                action.call(isSelected.value, total.value);
-              },
-              child: Image.asset(
-                imagePath,
-                color: isSelected.value ? activeColor : AppColors.gray50,
-                height: AppSpacing.s32,
-                width: AppSpacing.s32,
-              ),
-            ),
-            AppGap.h4,
-            Text(
-              "${total.value}",
-              style: AppTextStyles.textMedium(textColor: AppColors.gray50),
-            ),
-          ],
-        );
-      },
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        GestureDetector(
+          onTap: () {
+            setState(() {
+              isSelect = !isSelect;
+              isSelect ? total += 1 : total -= 1;
+            });
+            widget.action.call(widget.initialIsSelected, total);
+          },
+          child: Image.asset(
+            widget.imagePath,
+            color: isSelect
+                ? widget.activeColor
+                : AppColors.gray50,
+            height: AppSpacing.s32,
+            width: AppSpacing.s32,
+          ),
+        ),
+        AppGap.h4,
+        Text(
+          "${total}",
+          style: AppTextStyles.textMedium(textColor: AppColors.gray50),
+        ),
+      ],
     );
   }
 }

--- a/lib/presentation/community/widgets/community_post_comment_card.dart
+++ b/lib/presentation/community/widgets/community_post_comment_card.dart
@@ -34,7 +34,9 @@ class CommunityPostCommentCard extends StatelessWidget {
             imagePath: AppIcon.heart.path,
             total: heartTotal,
             activeColor: AppColors.red,
-            action: (isSelect, total) {},
+            action: (isSelect, total) {
+              //TODO: Comment 모델과 컨드롤러가 정의되면 추가
+            },
           ),
         ],
       ),

--- a/lib/presentation/community/widgets/community_post_comment_card.dart
+++ b/lib/presentation/community/widgets/community_post_comment_card.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:ondo/core/design_system/app_colors.dart';
+import 'package:ondo/core/design_system/app_icon.dart';
+import 'package:ondo/core/design_system/app_layout.dart';
+import 'package:ondo/core/design_system/app_text_styles.dart';
+import 'package:ondo/core/design_system/components/custom_profile_circle.dart';
+import 'package:ondo/presentation/community/widgets/community_custom_icon_button.dart';
+
+class CommunityPostCommentCard extends StatelessWidget {
+  const CommunityPostCommentCard({
+    super.key,
+    required this.author,
+    required this.commentText,
+    required this.heartTotal,
+  });
+
+  final String author;
+  final String commentText;
+  final int heartTotal;
+
+  @override
+  Widget build(BuildContext context) {
+    return IntrinsicHeight(
+      child: Row(
+        children: [
+          Align(
+            alignment: .topLeft,
+            child: CustomProfileCircle(radius: AppSpacing.s24),
+          ),
+          AppGap.h12,
+          Expanded(child: _body()),
+          AppGap.h6,
+          CommunityCustomIconButton(
+            imagePath: AppIcon.heart.path,
+            total: heartTotal,
+            activeColor: AppColors.red,
+            action: (isSelect, total) {},
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _body() => Column(
+    mainAxisSize: MainAxisSize.min,
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Text(
+        author,
+        style: AppTextStyles.caption(textColor: AppColors.gray60),
+      ),
+      AppGap.v6,
+      Text(
+        commentText,
+        style: AppTextStyles.caption(textColor: AppColors.gray90),
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+    ],
+  );
+}

--- a/lib/presentation/community/widgets/community_post_report_dialog.dart
+++ b/lib/presentation/community/widgets/community_post_report_dialog.dart
@@ -1,0 +1,111 @@
+
+import 'package:flutter/material.dart';
+import 'package:ondo/core/design_system/app_colors.dart';
+import 'package:ondo/core/design_system/app_layout.dart';
+import 'package:ondo/core/design_system/app_text_styles.dart';
+import 'package:ondo/core/design_system/component_variants.dart';
+import 'package:ondo/core/design_system/components/custom_button.dart';
+import 'package:ondo/core/design_system/components/custom_textfield.dart';
+import 'package:ondo/presentation/profile/widget/report_reason_chip.dart';
+
+class CommunityPostReportDialog extends StatefulWidget {
+  const CommunityPostReportDialog({
+    super.key,
+  });
+
+  @override
+  State<CommunityPostReportDialog> createState() => _CommunityPostReportDialogState();
+}
+
+class _CommunityPostReportDialogState extends State<CommunityPostReportDialog> {
+  final TextEditingController controller = TextEditingController();
+
+  final List<String> _reasons = [
+    "욕설이 많아요",
+    "상대를 존중하지 않아요",
+    "불쾌감을 느끼는 발언을 해요",
+    "공격적인 언어를 사용해요",
+    "신분, 장애, 인종에 대해 차별 발언을 일삼아요",
+    "부적절한 이름을 사용해요",
+    "기타",
+  ];
+
+  final Set<String> _selectedReasons = {};
+
+  bool get _isValid =>
+      _selectedReasons.isNotEmpty || controller.text.trim().isNotEmpty;
+
+  void _toggleReason(String reason) {
+    setState(() {
+      if (_selectedReasons.contains(reason)) {
+        _selectedReasons.remove(reason);
+      } else {
+        _selectedReasons.add(reason);
+      }
+    });
+  }
+
+  Future<void> _submitReport() async {
+    if (!_isValid) return;
+
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      alignment: Alignment.center,
+      backgroundColor: AppColors.white,
+      insetPadding: AppPadding.screenHorizontal,
+      child: Container(
+        padding: AppPadding.actionPopup,
+        decoration: BoxDecoration(
+          borderRadius: AppRadius.popupRadius,
+          color: AppColors.white,
+        ),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Center(child: Text("게시물 신고", style: AppTextStyles.titleBold20())),
+              AppGap.v16,
+              SizedBox(
+                width: MediaQuery.of(context).size.width,
+                child: Wrap(
+                  crossAxisAlignment: WrapCrossAlignment.start,
+                  spacing: AppSpacing.s12,
+                  runSpacing: AppSpacing.s12,
+                  children: _reasons.map(
+                        (e) {
+                      return ReportReasonChip(
+                        label: e,
+                        isSelected: _selectedReasons.contains(e),
+                        onTap: () => _toggleReason(e),
+                      );
+                    },
+                  ).toList(),
+                ),
+              ),
+              AppGap.v16,
+              CustomTextField(
+                controller: controller,
+                hintText: "상세 내용을 입력해주세요",
+                onChanged: (_) => setState(() {}),
+                minLines: 4,
+                maxLines: 4,
+              ),
+              AppGap.v16,
+              CustomButton(
+                text: "신고",
+                variant: ButtonVariant.primary,
+                enabled: _isValid,
+                onPressed: () => _submitReport(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/profile/widget/user_report_popup.dart
+++ b/lib/presentation/profile/widget/user_report_popup.dart
@@ -67,7 +67,7 @@ class _UserReportPopupState extends State<UserReportPopup> {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              Center(child: Text("유저 신고", style: AppTextStyles.popupTitle())),
+              Center(child: Text("유저 신고", style: AppTextStyles.titleBold20())),
               AppGap.v16,
               SizedBox(
                 width: MediaQuery.of(context).size.width,


### PR DESCRIPTION

## 📌 개요

> 커뮤니티 게시물 상세 페이지 정의

---

## 🧩 작업 내용

- [x]  상단 바 정의 (이전 버튼, 메뉴)
- [x]  _Title 정의 (제목, 태그 표시)
- [x]  _Body 정의 (작성자, 본문, 북마크/좋아요)
- [x]  댓글 리스트 정의 
- [x]  추천 게시물 리스트 정의

---

## 📎 참고 사항

- 디자인 시안 figma 커뮤니티 섹션에서 "커뮤니티 게시물 상세보기" 페이지 참고

close #86 
