### PR TITLE
[FEATURE] 스플래시 화면 Fade 애니메이션 적용

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -20,6 +20,8 @@ import 'package:ondo/presentation/auth/signup/screens/profile_image_setup_screen
 import 'package:ondo/presentation/auth/signup/screens/signup_complete_screen.dart';
 import 'package:ondo/presentation/auth/signup/screens/terms_agreement_screen.dart';
 import 'package:ondo/presentation/home/screens/home_screen.dart';
+import 'package:ondo/presentation/login/controllers/splash_controller.dart';
+import 'package:ondo/presentation/login/screens/splash.dart';
 import 'package:ondo/presentation/navigation/controllers/navigation_controller.dart';
 import 'package:ondo/presentation/navigation/screens/navigation_screen.dart';
 import 'package:ondo/presentation/profile/screens/edit_profile_screen.dart';
@@ -30,6 +32,7 @@ import 'package:ondo/presentation/profile/screens/terms_screen.dart';
 
 class RoutePaths {
   static const String navigation = '/';
+  static const String splash = '/splash';
 
   static const String home = '/home';
   static const String login = '/login';
@@ -53,8 +56,17 @@ class RoutePaths {
 }
 
 final GoRouter appRouter = GoRouter(
-  initialLocation: RoutePaths.navigation,
+  initialLocation: RoutePaths.splash,
   routes: [
+    GoRoute(
+      path: RoutePaths.splash,
+      name: 'splash',
+      builder: (context, state) {
+        Get.put(SplashController());
+        return SplashScreen();
+      },
+    ),
+
     GoRoute(
       path: RoutePaths.navigation,
       name: 'navigation',
@@ -172,12 +184,11 @@ final GoRouter appRouter = GoRouter(
       ],
     ),
   ],
-  errorBuilder: (context, state) =>
-      Scaffold(
-        body: Center(
-          child: Text('페이지르 찾을 수 없습니다.'),
-        ),
-      ),
+  errorBuilder: (context, state) => Scaffold(
+    body: Center(
+      child: Text('페이지르 찾을 수 없습니다.'),
+    ),
+  ),
 );
 
 class SignupBinding extends Bindings {

--- a/lib/presentation/login/controllers/splash_controller.dart
+++ b/lib/presentation/login/controllers/splash_controller.dart
@@ -1,39 +1,41 @@
-  import 'package:flutter/animation.dart';
-  import 'package:get/get.dart';
+import 'package:flutter/animation.dart';
+import 'package:get/get.dart';
 
-  class SplashController extends GetxController
-      with GetSingleTickerProviderStateMixin {
-    late final AnimationController animationController;
-    Animation<double>? opacity;
+class SplashController extends GetxController
+    with GetSingleTickerProviderStateMixin {
+  late final AnimationController animationController;
+  late final Animation<double> opacity;
+  Duration animationDuration = Duration(milliseconds: 1300);
 
-    final RxBool isReady = false.obs;
-    final RxBool isLogin = false.obs;
+  final RxBool isReady = false.obs;
+  final RxBool isLogin = false.obs;
 
-    @override
-    void onInit() {
-      super.onInit();
-      animationController = AnimationController(
-        vsync: this,
-        duration: Duration(milliseconds: 1300),
-      );
-      opacity = Tween<double>(begin: 0.0, end: 1.0).animate(
-        CurvedAnimation(parent: animationController, curve: Curves.easeIn),
-      );
+  @override
+  void onInit() {
+    super.onInit();
+    animationController = AnimationController(
+      vsync: this,
+      duration: animationDuration,
+    );
+    opacity = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(parent: animationController, curve: Curves.easeIn),
+    );
 
-      animationController.forward();
-      _bootstrap();
-    }
-
-    Future<void> _bootstrap() async {
-      await Future.delayed(Duration(milliseconds: 1500));
-
-      isReady.value = true;
-      isLogin.value = true;
-    }
-
-    @override
-    void onClose() {
-      super.onClose();
-      animationController.dispose();
-    }
+    animationController.forward();
+    _bootstrap();
   }
+
+  Future<void> _bootstrap() async {
+    await Future.delayed(const Duration(milliseconds: 1500));
+
+    // TODO: 실제 로그인 여부 확인 로직 구현 필요
+    isReady.value = true;
+    isLogin.value = true;
+  }
+
+  @override
+  void onClose() {
+    super.onClose();
+    animationController.dispose();
+  }
+}

--- a/lib/presentation/login/controllers/splash_controller.dart
+++ b/lib/presentation/login/controllers/splash_controller.dart
@@ -1,0 +1,39 @@
+  import 'package:flutter/animation.dart';
+  import 'package:get/get.dart';
+
+  class SplashController extends GetxController
+      with GetSingleTickerProviderStateMixin {
+    late final AnimationController animationController;
+    Animation<double>? opacity;
+
+    final RxBool isReady = false.obs;
+    final RxBool isLogin = false.obs;
+
+    @override
+    void onInit() {
+      super.onInit();
+      animationController = AnimationController(
+        vsync: this,
+        duration: Duration(milliseconds: 1300),
+      );
+      opacity = Tween<double>(begin: 0.0, end: 1.0).animate(
+        CurvedAnimation(parent: animationController, curve: Curves.easeIn),
+      );
+
+      animationController.forward();
+      _bootstrap();
+    }
+
+    Future<void> _bootstrap() async {
+      await Future.delayed(Duration(milliseconds: 1500));
+
+      isReady.value = true;
+      isLogin.value = true;
+    }
+
+    @override
+    void onClose() {
+      super.onClose();
+      animationController.dispose();
+    }
+  }

--- a/lib/presentation/login/screens/splash.dart
+++ b/lib/presentation/login/screens/splash.dart
@@ -1,19 +1,40 @@
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:go_router/go_router.dart';
 import 'package:ondo/core/design_system/app_icon.dart';
+import 'package:ondo/core/router/app_router.dart';
 import 'package:ondo/core/ui/base/base_scaffold.dart';
+import 'package:ondo/presentation/login/controllers/splash_controller.dart';
 
-
-class Splash extends StatelessWidget {
-  const Splash({super.key});
+class SplashScreen extends GetView<SplashController> {
+  const SplashScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
     return BaseScaffold(
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [Image.asset(AppIcon.logo.path)],
+        child: Obx(
+          () {
+            if (controller.isReady.value) {
+              log("${controller.isReady.value}");
+              WidgetsBinding.instance.addPostFrameCallback(
+                (timeStamp) => context.go(
+                  controller.isLogin.value
+                      ? RoutePaths.navigation
+                      : RoutePaths.login,
+                ),
+              );
+            }
+
+            if (controller.opacity == null) SizedBox();
+
+            return FadeTransition(
+              opacity: controller.opacity!,
+              child: Image.asset(AppIcon.logo.path),
+            );
+          },
         ),
       ),
     );

--- a/lib/presentation/login/screens/splash.dart
+++ b/lib/presentation/login/screens/splash.dart
@@ -1,5 +1,3 @@
-import 'dart:developer';
-
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:go_router/go_router.dart';
@@ -13,28 +11,22 @@ class SplashScreen extends GetView<SplashController> {
 
   @override
   Widget build(BuildContext context) {
+    once(
+      controller.isReady,
+      (callback) {
+        if (callback && context.mounted) {
+          context.go(
+            controller.isLogin.value ? RoutePaths.navigation : RoutePaths.login,
+          );
+        }
+      },
+    );
+
     return BaseScaffold(
       body: Center(
-        child: Obx(
-          () {
-            if (controller.isReady.value) {
-              log("${controller.isReady.value}");
-              WidgetsBinding.instance.addPostFrameCallback(
-                (timeStamp) => context.go(
-                  controller.isLogin.value
-                      ? RoutePaths.navigation
-                      : RoutePaths.login,
-                ),
-              );
-            }
-
-            if (controller.opacity == null) SizedBox();
-
-            return FadeTransition(
-              opacity: controller.opacity!,
-              child: Image.asset(AppIcon.logo.path),
-            );
-          },
+        child: FadeTransition(
+          opacity: controller.opacity,
+          child: Image.asset(AppIcon.logo.path),
         ),
       ),
     );

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,11 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
 import 'package:ondo/main.dart';
 import 'package:ondo/core/design_system/components/custom_button.dart';
 import 'package:ondo/core/design_system/components/custom_textfield.dart';
 import 'package:ondo/core/design_system/component_variants.dart';
 
 void main() {
+  /// 각 테스트가 종료될 때마다 실행됩니다.
+  /// GetX 컨트롤러와 타이머 잔류물을 깨끗하게 지워 CI 에러를 방지합니다.
+  tearDown(() {
+    Get.reset();
+  });
+
   group('ONDO App Widget Tests', () {
     testWidgets('CustomButton tap triggers onPressed', (
       WidgetTester tester,
@@ -68,6 +75,14 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(const MyApp());
+
+      // SplashController의 Future.delayed(1500ms)를 CI 환경에서 확실히 처리하기 위해
+      // runAsync 내부에서 실제 비동기 대기를 수행합니다.
+      await tester.runAsync(() async {
+        await Future.delayed(const Duration(milliseconds: 1600));
+      });
+
+      // 타이머 완료 후 발생하는 모든 애니메이션과 프레임 변화를 끝까지 처리합니다.
       await tester.pumpAndSettle();
 
       // MyApp 내 위젯 존재 여부 간단 체크

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -7,11 +7,9 @@ import 'package:ondo/core/design_system/components/custom_textfield.dart';
 import 'package:ondo/core/design_system/component_variants.dart';
 
 void main() {
-  /// 각 테스트가 종료될 때마다 실행됩니다.
-  /// GetX 컨트롤러와 타이머 잔류물을 깨끗하게 지워 CI 에러를 방지합니다.
-  tearDown(() {
-    Get.reset();
-  });
+  // 테스트마다 GetX 상태를 완전히 초기화합니다.
+  setUp(() => Get.reset());
+  tearDown(() => Get.reset());
 
   group('ONDO App Widget Tests', () {
     testWidgets('CustomButton tap triggers onPressed', (
@@ -31,44 +29,23 @@ void main() {
             ),
           ),
         ),
-      );
-
-      // 버튼이 화면에 있는지 확인
-      expect(find.text('Test Button'), findsOneWidget);
-
-      // 버튼 탭
-      await tester.tap(find.byType(CustomButton));
+      ));
+      await tester.tap(find.text('Test Button'));
       await tester.pump();
-
-      // onPressed 실행 확인
       expect(tapped, true);
     });
 
+    // 2. CustomTextField 테스트
     testWidgets('CustomTextField accepts input', (WidgetTester tester) async {
       final controller = TextEditingController();
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: CustomTextField(
-              controller: controller,
-              hintText: '테스트',
-            ),
-          ),
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: CustomTextField(controller: controller, hintText: '테스트'),
         ),
-      );
-
-      // TextField 찾기
-      final textField = find.byType(TextFormField);
-      expect(textField, findsOneWidget);
-
-      // 입력 테스트
-      await tester.enterText(textField, 'Eunseo');
+      ));
+      await tester.enterText(find.byType(TextFormField), 'Eunseo');
       await tester.pump();
-
-      // 입력 값 확인
       expect(controller.text, 'Eunseo');
-      expect(find.text('Eunseo'), findsOneWidget);
     });
 
     testWidgets('Main app renders without crashing', (
@@ -76,16 +53,14 @@ void main() {
     ) async {
       await tester.pumpWidget(const MyApp());
 
-      // SplashController의 Future.delayed(1500ms)를 CI 환경에서 확실히 처리하기 위해
-      // runAsync 내부에서 실제 비동기 대기를 수행합니다.
-      await tester.runAsync(() async {
-        await Future.delayed(const Duration(milliseconds: 1600));
-      });
+      // [핵심 수정] runAsync 대신 가상 시간을 직접 2초 흐르게 합니다.
+      // SplashController의 1.5초 타이머를 만료시키기 위함입니다.
+      await tester.pump(const Duration(milliseconds: 2000));
 
-      // 타이머 완료 후 발생하는 모든 애니메이션과 프레임 변화를 끝까지 처리합니다.
+      // 타이머 만료 후 발생하는 모든 애니메이션이 끝날 때까지 대기합니다.
       await tester.pumpAndSettle();
 
-      // MyApp 내 위젯 존재 여부 간단 체크
+      // 위젯이 잘 렌더링 되었는지 확인합니다.
       expect(find.byType(MyApp), findsOneWidget);
     });
   });

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -12,21 +12,15 @@ void main() {
   tearDown(() => Get.reset());
 
   group('ONDO App Widget Tests', () {
-    testWidgets('CustomButton tap triggers onPressed', (
-      WidgetTester tester,
-    ) async {
+    // 1. CustomButton 테스트
+    testWidgets('CustomButton tap triggers onPressed', (WidgetTester tester) async {
       bool tapped = false;
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: CustomButton(
-              text: 'Test Button',
-              variant: ButtonVariant.primary,
-              onPressed: () {
-                tapped = true;
-              },
-            ),
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: CustomButton(
+            text: 'Test Button',
+            variant: ButtonVariant.primary,
+            onPressed: () => tapped = true,
           ),
         ),
       ));
@@ -48,9 +42,9 @@ void main() {
       expect(controller.text, 'Eunseo');
     });
 
-    testWidgets('Main app renders without crashing', (
-      WidgetTester tester,
-    ) async {
+    // 3. 메인 앱 렌더링 테스트
+    testWidgets('Main app renders without crashing', (WidgetTester tester) async {
+      // 앱을 빌드합니다.
       await tester.pumpWidget(const MyApp());
 
       // [핵심 수정] runAsync 대신 가상 시간을 직접 2초 흐르게 합니다.


### PR DESCRIPTION
## 📌 개요

> 앱 실행 시 표시되는 SplashScreen에 fade-in 애니메이션을 적용했습니다.
StatefulWidget 구조를 제거하고 GetView 기반 구조로 리팩터링했습니다.

---

## 🧩 작업내용

- [x] SplashScreen을 GetView<SplashController> 구조로 변경
- [x] GetSingleTickerProviderStateMixin 적용
- [x] AnimationController 기반 fade-in 애니메이션 구현
- [x] FadeTransition 위젯으로 애니메이션 처리
- [x] bootstrap 로직 추가
- [x] AnimationController dispose 처리

---

## 📎 Notes

- Animation은 Obx가 아닌 FadeTransition으로 처리
- Rx 상태는 isReady / isLogin에만 사용
- animationController는 onClose에서 dispose 처리

---

Resolve: #89