### PR TITLE
[FEATURE] 회원가입 프로필 이미지 Presign URL 업로드 구현

### DIFF
--- a/lib/core/router/bindings/login_binding.dart
+++ b/lib/core/router/bindings/login_binding.dart
@@ -3,6 +3,8 @@ import 'package:ondo/core/env.dart';
 import 'package:ondo/data/datasource/auth/auth_local_datasource_impl.dart';
 import 'package:ondo/data/datasource/auth/auth_remote_datasource.dart';
 import 'package:ondo/data/datasource/base/auth_local_datasource.dart';
+import 'package:ondo/data/datasource/media/media_remote_datasource.dart';
+import 'package:ondo/data/network/clients/auth_client.dart';
 import 'package:ondo/data/repositories/auth/auth_repository_impl.dart';
 import 'package:ondo/domain/repositories/auth/auth_repository.dart';
 import 'package:ondo/domain/usecases/auth/sign_in_use_case.dart';
@@ -11,30 +13,46 @@ import 'package:ondo/presentation/auth/login/controllers/login_controller.dart';
 class LoginBinding extends Bindings {
   @override
   void dependencies() {
-    ///인증 관련 dataSource 등록
+    /// 인증 관련 dataSource 등록
     Get.lazyPut<AuthRemoteDatasource>(
-      () => AuthRemoteDatasource(Env.apiBaseUrl),
+          () => AuthRemoteDatasource(Env.apiBaseUrl),
     );
     Get.lazyPut<AuthLocalDatasource>(
-      () => AuthLocalDatasourceImpl(),
+          () => AuthLocalDatasourceImpl(),
     );
 
-    ///인증 관련 repository 등록
+    /// 인증 관련 repository 등록
     Get.lazyPut<AuthRepository>(
-      () => AuthRepositoryImpl(
+          () => AuthRepositoryImpl(
         localDatasource: Get.find<AuthLocalDatasource>(),
         remoteDatasource: Get.find<AuthRemoteDatasource>(),
       ),
     );
 
-    ///로그인 usecase 등록
+    /// 로그인 usecase 등록
     Get.lazyPut<SignInUseCase>(
-      () => SignInUseCase(repository: Get.find<AuthRepository>()),
+          () => SignInUseCase(repository: Get.find<AuthRepository>()),
     );
 
-    ///최종적으로 LoginController 등록
+    /// 이미지 업로드용 AuthClient 등록
+    Get.lazyPut<AuthClient>(
+          () => AuthClient(
+        localDatasource: Get.find<AuthLocalDatasource>(),
+        remoteDatasource: Get.find<AuthRemoteDatasource>(),
+      ),
+    );
+
+    /// 미디어 업로드용 datasource 등록
+    Get.lazyPut<MediaRemoteDatasource>(
+          () => MediaRemoteDatasource(client: Get.find<AuthClient>()),
+    );
+
+    /// 최종적으로 LoginController 등록
     Get.lazyPut<LoginController>(
-      () => LoginController(signInUseCase: Get.find<SignInUseCase>()),
+          () => LoginController(
+        signInUseCase: Get.find<SignInUseCase>(),
+        mediaRemoteDatasource: Get.find<MediaRemoteDatasource>(),
+      ),
     );
   }
 }

--- a/lib/core/router/bindings/splash_binding.dart
+++ b/lib/core/router/bindings/splash_binding.dart
@@ -1,9 +1,18 @@
 import 'package:get/get.dart';
+import 'package:ondo/data/datasource/auth/auth_local_datasource_impl.dart';
+import 'package:ondo/data/datasource/base/auth_local_datasource.dart';
 import 'package:ondo/presentation/auth/login/controllers/splash_controller.dart';
 
 class SplashBinding extends Bindings {
   @override
   void dependencies() {
-    Get.lazyPut<SplashController>(() => SplashController());
+    Get.lazyPut<AuthLocalDatasource>(
+          () => AuthLocalDatasourceImpl(),
+      fenix: true,
+    );
+
+    Get.lazyPut<SplashController>(
+          () => SplashController(localDatasource: Get.find()),
+    );
   }
 }

--- a/lib/data/datasource/media/media_remote_datasource.dart
+++ b/lib/data/datasource/media/media_remote_datasource.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:ondo/data/models/media/request/presign_upload_request_model.dart';
+import 'package:ondo/data/models/media/response/presign_upload_response_model.dart';
+import 'package:ondo/data/network/clients/auth_client.dart';
+import 'package:ondo/data/network/constants/api_constants.dart';
+import 'package:http/http.dart' as http;
+
+class MediaRemoteDatasource {
+  final AuthClient client;
+
+  MediaRemoteDatasource({required this.client});
+
+  /// 1단계: presign URL 발급
+  Future<PresignUploadData> getPresignUrl({
+    required String category,
+    required String contentType,
+  }) async {
+    final log = ApiConstants(logName: '이미지 presign URL 발급');
+
+    final model = PresignUploadRequestModel(
+      category: category,
+      contentType: contentType,
+    );
+
+    final res = await client.post(
+      Uri.parse('${ApiConstants.domain}/media/presign/upload'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(model.toJson()),
+    );
+
+    final body = jsonDecode(res.body);
+    log.successLog(body['success'] ?? false);
+    log.messageLog(body['message'] ?? '');
+
+    if (res.statusCode != 200 || body['success'] != true) {
+      log.statusLog(res.statusCode);
+      throw Exception('presign URL 발급 실패: ${body['message']}');
+    }
+
+    final responseModel = PresignUploadResponseModel.fromJson(body);
+
+    if (responseModel.data == null) {
+      throw Exception('presign URL 데이터가 없습니다.');
+    }
+
+    return responseModel.data!;
+  }
+
+  /// 2단계: S3에 이미지 업로드 (binary PUT)
+  Future<void> uploadImageToS3({
+    required String presignUrl,
+    required String imagePath,
+    required String contentType,
+  }) async {
+    final log = ApiConstants(logName: 'S3 이미지 업로드');
+
+    final file = File(imagePath);
+    final bytes = await file.readAsBytes();
+
+    // S3 presign URL은 인증 헤더 없이 직접 PUT
+    final res = await http.put(
+      Uri.parse(presignUrl),
+      headers: {'Content-Type': contentType},
+      body: bytes,
+    );
+
+    log.statusLog(res.statusCode);
+
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      throw Exception('S3 이미지 업로드 실패: ${res.statusCode}');
+    }
+
+    if (kDebugMode) debugPrint('[S3 업로드 완료]');
+  }
+
+  /// presign 발급 + S3 업로드 한 번에 처리 → key 반환
+  Future<String> uploadImage({
+    required String imagePath,
+    String category = 'PROFILE',
+  }) async {
+    // 확장자로 contentType 결정
+    final ext = imagePath.split('.').last.toLowerCase();
+    final contentType = switch (ext) {
+      'png' => 'image/png',
+      'webp' => 'image/webp',
+      _ => 'image/jpeg',
+    };
+
+    final presignData = await getPresignUrl(
+      category: category,
+      contentType: contentType,
+    );
+
+    await uploadImageToS3(
+      presignUrl: presignData.url,
+      imagePath: imagePath,
+      contentType: contentType,
+    );
+
+    return presignData.key;
+  }
+}

--- a/lib/data/datasource/media/media_remote_datasource.dart
+++ b/lib/data/datasource/media/media_remote_datasource.dart
@@ -2,11 +2,12 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
 import 'package:ondo/data/models/media/request/presign_upload_request_model.dart';
 import 'package:ondo/data/models/media/response/presign_upload_response_model.dart';
 import 'package:ondo/data/network/clients/auth_client.dart';
 import 'package:ondo/data/network/constants/api_constants.dart';
-import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
 
 class MediaRemoteDatasource {
   final AuthClient client;
@@ -81,12 +82,13 @@ class MediaRemoteDatasource {
     required String imagePath,
     String category = 'PROFILE',
   }) async {
-    // 확장자로 contentType 결정
-    final ext = imagePath.split('.').last.toLowerCase();
+    // path 패키지로 파일명에서만 확장자 추출 (디렉토리 경로의 점 영향 없음)
+    final ext = p.extension(imagePath).replaceFirst('.', '').toLowerCase();
     final contentType = switch (ext) {
       'png' => 'image/png',
       'webp' => 'image/webp',
-      _ => 'image/jpeg',
+      'jpg' || 'jpeg' => 'image/jpeg',
+      _ => 'image/jpeg', // 확장자 없거나 알 수 없는 경우 기본값
     };
 
     final presignData = await getPresignUrl(

--- a/lib/data/models/media/request/presign_upload_request_model.dart
+++ b/lib/data/models/media/request/presign_upload_request_model.dart
@@ -1,0 +1,14 @@
+class PresignUploadRequestModel {
+  final String category;
+  final String contentType;
+
+  const PresignUploadRequestModel({
+    required this.category,
+    required this.contentType,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'category': category,
+    'contentType': contentType,
+  };
+}

--- a/lib/data/models/media/response/presign_upload_response_model.dart
+++ b/lib/data/models/media/response/presign_upload_response_model.dart
@@ -1,0 +1,41 @@
+class PresignUploadResponseModel {
+  final bool success;
+  final String message;
+  final PresignUploadData? data;
+
+  PresignUploadResponseModel({
+    required this.success,
+    required this.message,
+    this.data,
+  });
+
+  factory PresignUploadResponseModel.fromJson(Map json) {
+    return PresignUploadResponseModel(
+      success: json['success'] ?? false,
+      message: json['message'] ?? '',
+      data: json['data'] != null
+          ? PresignUploadData.fromJson(json['data'])
+          : null,
+    );
+  }
+}
+
+class PresignUploadData {
+  final String key;
+  final String url;
+  final String expiresAt;
+
+  PresignUploadData({
+    required this.key,
+    required this.url,
+    required this.expiresAt,
+  });
+
+  factory PresignUploadData.fromJson(Map json) {
+    return PresignUploadData(
+      key: json['key'],
+      url: json['url'],
+      expiresAt: json['expiresAt'],
+    );
+  }
+}

--- a/lib/presentation/auth/login/controllers/login_controller.dart
+++ b/lib/presentation/auth/login/controllers/login_controller.dart
@@ -1,20 +1,21 @@
-import 'package:get/get.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:ondo/core/design_system/app_strings.dart';
 import 'package:ondo/domain/usecases/auth/sign_in_use_case.dart';
 
 class LoginController extends GetxController {
-  final emailController = TextEditingController();
-  final passwordController = TextEditingController();
-
   final SignInUseCase signInUseCase;
 
   LoginController({required this.signInUseCase});
+
+  final emailController = TextEditingController();
+  final passwordController = TextEditingController();
 
   var emailError = RxnString();
   var passwordError = RxnString();
   var generalError = RxnString();
   var showPassword = false.obs;
+  var isLoading = false.obs;
 
   bool validate() {
     emailError.value = null;
@@ -36,14 +37,8 @@ class LoginController extends GetxController {
       return false;
     }
 
-    if (password.length < 8 || password.length > 15) {
+    if (password.length < 8 || password.length > 50) {
       passwordError.value = AppStrings.passwordLength;
-      return false;
-    }
-
-    final passwordRegex = RegExp(r'[!@#$%^&*(),.?":{}|<>]');
-    if (!passwordRegex.hasMatch(password)) {
-      passwordError.value = AppStrings.passwordRegex;
       return false;
     }
 
@@ -52,18 +47,32 @@ class LoginController extends GetxController {
 
   Future<bool> login() async {
     if (!validate()) return false;
+    if (isLoading.value) return false;
 
-    final result = await signInUseCase.call(
-      loginId: emailController.text.trim(),
-      password: passwordController.text.trim(),
-    );
+    try {
+      isLoading.value = true;
 
-    if (result) {
+      // loginId = 이메일 @ 앞부분 (회원가입 시 동일하게 처리)
+      final loginId = emailController.text.trim().split('@').first;
+
+      final success = await signInUseCase(
+        loginId: loginId,
+        password: passwordController.text,
+      );
+
+      if (!success) {
+        generalError.value = AppStrings.inputEmailOrPassword;
+        return false;
+      }
+
       generalError.value = null;
-    } else {
+      return true;
+    } catch (e) {
       generalError.value = AppStrings.inputEmailOrPassword;
+      return false;
+    } finally {
+      isLoading.value = false;
     }
-    return result;
   }
 
   @override

--- a/lib/presentation/auth/login/controllers/login_controller.dart
+++ b/lib/presentation/auth/login/controllers/login_controller.dart
@@ -1,12 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:ondo/core/design_system/app_strings.dart';
+import 'package:ondo/data/datasource/media/media_remote_datasource.dart';
 import 'package:ondo/domain/usecases/auth/sign_in_use_case.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class LoginController extends GetxController {
   final SignInUseCase signInUseCase;
+  final MediaRemoteDatasource mediaRemoteDatasource;
 
-  LoginController({required this.signInUseCase});
+  LoginController({
+    required this.signInUseCase,
+    required this.mediaRemoteDatasource,
+  });
+
+  static const String _profileImagePathKey = 'pending_profile_image_path';
 
   final emailController = TextEditingController();
   final passwordController = TextEditingController();
@@ -66,12 +74,46 @@ class LoginController extends GetxController {
       }
 
       generalError.value = null;
+
+      // 로그인 성공 후 대기 중인 프로필 이미지 업로드 처리
+      await _uploadPendingProfileImage();
+
       return true;
     } catch (e) {
       generalError.value = AppStrings.inputEmailOrPassword;
       return false;
     } finally {
       isLoading.value = false;
+    }
+  }
+
+  /// SharedPreferences에 저장된 프로필 이미지 경로 확인 후 업로드
+  Future<void> _uploadPendingProfileImage() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final imagePath = prefs.getString(_profileImagePathKey);
+
+      if (imagePath == null || imagePath.isEmpty) return;
+
+      debugPrint('[프로필 이미지 업로드 시작] path: $imagePath');
+
+      await mediaRemoteDatasource.uploadImage(imagePath: imagePath);
+
+      // 업로드 완료 후 임시 데이터 삭제
+      await prefs.remove(_profileImagePathKey);
+
+      debugPrint('[프로필 이미지 업로드 완료]');
+    } catch (e, s) {
+      // 이미지 업로드 실패해도 로그인은 성공으로 처리
+      debugPrint('프로필 이미지 업로드 실패 (무시): $e\n$s');
+    }
+  }
+
+  /// 회원가입 완료 후 이미지 경로를 SharedPreferences에 임시 저장
+  static Future<void> savePendingProfileImage(String? imagePath) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (imagePath != null && imagePath.isNotEmpty) {
+      await prefs.setString(_profileImagePathKey, imagePath);
     }
   }
 

--- a/lib/presentation/auth/login/controllers/splash_controller.dart
+++ b/lib/presentation/auth/login/controllers/splash_controller.dart
@@ -1,11 +1,16 @@
 import 'package:flutter/animation.dart';
 import 'package:get/get.dart';
+import 'package:ondo/data/datasource/base/auth_local_datasource.dart';
 
 class SplashController extends GetxController
     with GetSingleTickerProviderStateMixin {
+  final AuthLocalDatasource localDatasource;
+
+  SplashController({required this.localDatasource});
+
   late final AnimationController animationController;
   late final Animation<double> opacity;
-  Duration animationDuration = Duration(milliseconds: 1300);
+  Duration animationDuration = const Duration(milliseconds: 1300);
 
   final RxBool isReady = false.obs;
   final RxBool isLogin = false.obs;
@@ -28,14 +33,39 @@ class SplashController extends GetxController
   Future<void> _bootstrap() async {
     await Future.delayed(const Duration(milliseconds: 1500));
 
-    // TODO: 실제 로그인 여부 확인 로직 구현 필요
+    isLogin.value = await _checkLoginStatus();
     isReady.value = true;
-    isLogin.value = true;
+  }
+
+  /// 저장된 토큰 유효성 확인
+  Future<bool> _checkLoginStatus() async {
+    final token = await localDatasource.getAccessToken();
+    if (token == null || token.isEmpty) return false;
+
+    final expirationStr = await localDatasource.getAccessTokenExpiration();
+    if (expirationStr == null) return false;
+
+    final expiration = DateTime.tryParse(expirationStr);
+    if (expiration == null) return false;
+
+    // refreshToken도 확인
+    final refreshToken = await localDatasource.getRefreshToken();
+    if (refreshToken == null || refreshToken.isEmpty) return false;
+
+    final refreshExpirationStr =
+    await localDatasource.getRefreshTokenExpiration();
+    if (refreshExpirationStr == null) return false;
+
+    final refreshExpiration = DateTime.tryParse(refreshExpirationStr);
+    if (refreshExpiration == null) return false;
+
+    // refreshToken이 유효하면 로그인 상태로 간주
+    return DateTime.now().isBefore(refreshExpiration);
   }
 
   @override
   void onClose() {
-    super.onClose();
     animationController.dispose();
+    super.onClose();
   }
 }

--- a/lib/presentation/auth/signup/controllers/signup_profile_image_setup_controller.dart
+++ b/lib/presentation/auth/signup/controllers/signup_profile_image_setup_controller.dart
@@ -1,11 +1,14 @@
 import 'dart:developer';
+
 import 'package:get/get.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:ondo/presentation/auth/signup/controllers/signup_flow_controller.dart';
 
 class SignupProfileImageSetupController extends GetxController {
   final flowController = Get.find<SignupFlowController>();
+
   String? profileImagePath;
+  final isLoading = false.obs;
 
   final ImagePicker _picker = ImagePicker();
 
@@ -18,23 +21,29 @@ class SignupProfileImageSetupController extends GetxController {
 
   Future<void> pickFromGallery() async {
     try {
-      final XFile? image = await _picker.pickImage(source: ImageSource.gallery);
-
+      final XFile? image = await _picker.pickImage(
+        source: ImageSource.gallery,
+        imageQuality: 80,
+      );
       if (image != null) {
         profileImagePath = image.path;
         update();
       }
-    } catch(e){
-      log("image picker error: $e");
+    } catch (e) {
+      log('image picker error: $e');
     }
   }
 
+  /// 로컬 경로만 flowController에 저장
+  /// 실제 업로드는 로그인 후 MediaRemoteDatasource에서 처리
   void submitProfileImage() {
     flowController.setProfileImagePath(profileImagePath);
+    flowController.setProfileImageKey(null); // 업로드 전이므로 key는 null
+
     log(
       isDefaultProfile
-          ? '프로필 이미지 설정완료: 기본 프로필'
-          : '프로필 이미지 설정완료: $profileImagePath',
+          ? '프로필 이미지: 기본 프로필로 진행'
+          : '프로필 이미지 로컬 경로 저장: $profileImagePath',
     );
   }
 }

--- a/lib/presentation/auth/signup/screens/signup_complete_screen.dart
+++ b/lib/presentation/auth/signup/screens/signup_complete_screen.dart
@@ -7,7 +7,9 @@ import 'package:ondo/core/design_system/app_strings.dart';
 import 'package:ondo/core/design_system/app_text_styles.dart';
 import 'package:ondo/core/design_system/component_variants.dart';
 import 'package:ondo/core/design_system/components/custom_button.dart';
+import 'package:ondo/core/router/app_router.dart';
 import 'package:ondo/core/ui/base/base_scaffold.dart';
+import 'package:ondo/presentation/auth/login/controllers/login_controller.dart';
 import 'package:ondo/presentation/auth/signup/controllers/signup_flow_controller.dart';
 import 'package:ondo/presentation/auth/signup/widgets/title_text.dart';
 
@@ -37,19 +39,13 @@ class SignupCompleteScreen extends GetView<SignupFlowController> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         AppGap.v51,
-
-        /// 닉네임 표시
         Text(
           '*닉네임 ${controller.nickname ?? ''}로 회원가입되었어요!',
-          style: AppTextStyles.caption(
-            textColor: AppColors.gray70,
-          ),
+          style: AppTextStyles.caption(textColor: AppColors.gray70),
         ),
-
         AppGap.v8,
         TitleText.titleText(AppStrings.signupCompletionTitle),
         AppGap.v24,
-
         Text(
           AppStrings.guidelineAvoidSevereCriticism,
           style: AppTextStyles.textMedium(),
@@ -67,32 +63,48 @@ class SignupCompleteScreen extends GetView<SignupFlowController> {
         AppGap.v12,
         Text(
           AppStrings.ruleViolationWarning,
-          style: AppTextStyles.textMedium(
-            textColor: AppColors.red,
-          ),
+          style: AppTextStyles.textMedium(textColor: AppColors.red),
         ),
       ],
     );
   }
 
   Widget _buildStartButton(BuildContext context) {
-    return Column(
-      children: [
-        GetBuilder<SignupFlowController>(
-          builder: (controller) {
-            return CustomButton(
-              text: '시작하기',
-              variant: ButtonVariant.primary,
-              //enabled: controller.canSubmit,
-              onPressed: () {
-                controller.submitInfo();
-                context.goNamed('login');
-              },
-            );
-          },
-        ),
-        AppGap.v16,
-      ],
+    return Obx(
+          () => Column(
+        children: [
+          CustomButton(
+            text: '시작하기',
+            variant: ButtonVariant.primary,
+            enabled: !controller.isLoading.value,
+            onPressed: controller.isLoading.value
+                ? null
+                : () async {
+              final success = await controller.submitInfo();
+              if (!context.mounted) return;
+
+              if (!success) {
+                Get.snackbar(
+                  '회원가입 실패',
+                  '회원가입에 실패했습니다. 다시 시도해주세요.',
+                  snackPosition: SnackPosition.BOTTOM,
+                );
+                return;
+              }
+
+              // 프로필 이미지 경로 임시 저장 (로그인 후 업로드)
+              final imagePath = controller.profileImagePath;
+              controller.clear();
+
+              await LoginController.savePendingProfileImage(imagePath);
+              if (!context.mounted) return;
+
+              context.go(RoutePaths.login);
+            },
+          ),
+          AppGap.v16,
+        ],
+      ),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -436,10 +436,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -489,7 +489,7 @@ packages:
     source: hosted
     version: "2.1.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
@@ -745,10 +745,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   web_socket_channel: ^3.0.3
   intl: ^0.20.2
   go_router: ^17.0.1
+  path: ^1.9.1
 
 
 dev_dependencies:


### PR DESCRIPTION
## 📌 개요
회원가입 시점에는 Bearer 토큰이 없어 /media/presign/upload 호출이 불가능하다.
프로필 이미지 경로를 SharedPreferences에 임시 저장하고, 로그인 성공 후 Presign URL 방식으로 S3에 업로드 및 프로필에 반영한다.

## 🧩 작업 내용
- [x] 로그인 API 연동 (LoginController SignInUseCase 실제 호출)
- [x] Splash 토큰 기반 로그인 여부 확인 구현
- [x] PresignUploadRequestModel, PresignUploadResponseModel 생성
- [x] MediaRemoteDatasource 생성 (getPresignUrl, uploadImageToS3)
- [x] SignupProfileImageSetupController 로컬 경로 저장으로 변경
- [x] SignupCompleteScreen 가입 완료 시 이미지 경로 SharedPreferences 임시 저장
- [x] LoginController 로그인 성공 후 대기 이미지 업로드 처리
- [x] LoginBinding MediaRemoteDatasource 의존성 추가

## 📎 참고 사항
- API 명세: POST /media/presign/upload, PUT {presignUrl}
- profileImageKey는 회원가입 시 null 허용

close #105