### PR TITLE
[FEATURE] 채팅방 메세지 읽음 처리 API 연동

### DIFF
--- a/lib/core/design_system/components/custom_back_button.dart
+++ b/lib/core/design_system/components/custom_back_button.dart
@@ -15,12 +15,14 @@ class CustomBackButton extends StatelessWidget {
     this.useUserProfile = false,
     this.userInfo,
     this.itemBuilder,
+    this.backAction,
   });
 
   final bool moreOptions;
   final bool useUserProfile;
   final (Widget profile, String name)? userInfo;
   final PopupMenuItemBuilder<String>? itemBuilder;
+  final VoidCallback? backAction;
 
   @override
   Widget build(BuildContext context) {
@@ -45,7 +47,7 @@ class CustomBackButton extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.start,
             children: [
               GestureDetector(
-                onTap: Get.back,
+                onTap: backAction ?? Get.back,
                 child: SvgPicture.asset(AppIcon.arrowLeft.path),
               ),
               if (!useUserProfile) _text() else _profile(),

--- a/lib/core/router/bindings/chat_binding.dart
+++ b/lib/core/router/bindings/chat_binding.dart
@@ -5,6 +5,7 @@ import 'package:ondo/domain/usecases/chat/block_chat_room_use_case.dart';
 import 'package:ondo/domain/usecases/chat/cancel_block_chat_room_use_case.dart';
 import 'package:ondo/domain/usecases/chat/create_chat_room_use_case.dart';
 import 'package:ondo/domain/usecases/chat/load_my_chat_room_list_use_case.dart';
+import 'package:ondo/domain/usecases/chat/read_chat_message_use_case.dart';
 import 'package:ondo/presentation/chat/controllers/chat_main_controller.dart';
 
 import '../../../data/network/clients/auth_client.dart';
@@ -40,10 +41,14 @@ class ChatBinding extends Bindings {
         repository: Get.find<ChatRepositoryImpl>(),
       ),
     );
+    Get.lazyPut<ReadChatMessageUseCase>(
+      () => ReadChatMessageUseCase(repository: Get.find<ChatRepositoryImpl>()),
+    );
 
     ///chat controller 등록
     Get.lazyPut(
       () => ChatMainController(
+        readChatMessageUseCase: Get.find<ReadChatMessageUseCase>(),
         cancelBlockChatRoomUseCase: Get.find<CancelBlockChatRoomUseCase>(),
         blockChatRoomUseCase: Get.find<BlockChatRoomUseCase>(),
         loadChatRoomsUseCase: Get.find<LoadMyChatRoomListUseCase>(),

--- a/lib/core/router/bindings/chat_binding.dart
+++ b/lib/core/router/bindings/chat_binding.dart
@@ -5,7 +5,6 @@ import 'package:ondo/domain/usecases/chat/block_chat_room_use_case.dart';
 import 'package:ondo/domain/usecases/chat/cancel_block_chat_room_use_case.dart';
 import 'package:ondo/domain/usecases/chat/create_chat_room_use_case.dart';
 import 'package:ondo/domain/usecases/chat/load_my_chat_room_list_use_case.dart';
-import 'package:ondo/domain/usecases/chat/read_chat_message_use_case.dart';
 import 'package:ondo/presentation/chat/controllers/chat_main_controller.dart';
 
 import '../../../data/network/clients/auth_client.dart';
@@ -41,14 +40,10 @@ class ChatBinding extends Bindings {
         repository: Get.find<ChatRepositoryImpl>(),
       ),
     );
-    Get.lazyPut<ReadChatMessageUseCase>(
-      () => ReadChatMessageUseCase(repository: Get.find<ChatRepositoryImpl>()),
-    );
 
     ///chat controller 등록
     Get.lazyPut(
       () => ChatMainController(
-        readChatMessageUseCase: Get.find<ReadChatMessageUseCase>(),
         cancelBlockChatRoomUseCase: Get.find<CancelBlockChatRoomUseCase>(),
         blockChatRoomUseCase: Get.find<BlockChatRoomUseCase>(),
         loadChatRoomsUseCase: Get.find<LoadMyChatRoomListUseCase>(),

--- a/lib/core/router/bindings/chat_room_binding.dart
+++ b/lib/core/router/bindings/chat_room_binding.dart
@@ -3,6 +3,8 @@ import 'package:ondo/data/repositories/chat/chat_repository_impl.dart';
 import 'package:ondo/domain/usecases/chat/load_chat_room_message_use_case.dart';
 import 'package:ondo/presentation/chat/controllers/chat_room_controller.dart';
 
+import '../../../domain/usecases/chat/read_chat_message_use_case.dart';
+
 class ChatRoomBinding extends Bindings {
   final String chatRoomId;
 
@@ -15,9 +17,13 @@ class ChatRoomBinding extends Bindings {
         repository: Get.find<ChatRepositoryImpl>(),
       ),
     );
+    Get.lazyPut<ReadChatMessageUseCase>(
+      () => ReadChatMessageUseCase(repository: Get.find<ChatRepositoryImpl>()),
+    );
     Get.put<ChatRoomController>(
       ChatRoomController(
         chatRoomId: chatRoomId,
+        readChatMessageUseCase: Get.find<ReadChatMessageUseCase>(),
         loadChatRoomMessageUseCase: Get.find<LoadChatRoomMessageUseCase>(),
       ),
       tag: chatRoomId,

--- a/lib/data/datasource/chat/chat_remote_datasource.dart
+++ b/lib/data/datasource/chat/chat_remote_datasource.dart
@@ -137,4 +137,32 @@ class ChatRemoteDatasource {
 
     return null;
   }
+
+  Future<bool> readChatMessage(
+    String chatRoomPublicId,
+    num lastReadMessageId,
+  ) async {
+    final log = ApiConstants(logName: "채팅방 읽음 처리");
+
+    try {
+      final res = await client.patch(
+        Uri.parse(
+          "${ApiConstants.chats}/rooms/$chatRoomPublicId/read?lastReadMessageId=$lastReadMessageId",
+        ),
+      );
+
+      final body = jsonDecode(res.body);
+
+      log.successLog(body["success"] == true);
+      log.messageLog(body["message"]);
+      if (res.statusCode == 200 && body["success"] == true) {
+        return true;
+      }
+      log.statusLog(res.statusCode);
+    } catch (e) {
+      log.errorLog(e);
+    }
+
+    return false;
+  }
 }

--- a/lib/data/datasource/chat/chat_remote_datasource.dart
+++ b/lib/data/datasource/chat/chat_remote_datasource.dart
@@ -140,7 +140,7 @@ class ChatRemoteDatasource {
 
   Future<bool> readChatMessage(
     String chatRoomPublicId,
-    num lastReadMessageId,
+    int lastReadMessageId,
   ) async {
     final log = ApiConstants(logName: "채팅방 읽음 처리");
 

--- a/lib/data/repositories/chat/chat_repository_impl.dart
+++ b/lib/data/repositories/chat/chat_repository_impl.dart
@@ -73,4 +73,17 @@ class ChatRepositoryImpl extends ChatRepository {
         .map((e) => ChatMessageEntity.fromJsonChatMessageModel(e))
         .toList();
   }
+
+  @override
+  Future<bool> readChatMessage(
+    String chatRoomPublicId,
+    num lastReadMessageId,
+  ) async {
+    final res = await remoteDatasource.readChatMessage(
+      chatRoomPublicId,
+      lastReadMessageId,
+    );
+
+    return res;
+  }
 }

--- a/lib/data/repositories/chat/chat_repository_impl.dart
+++ b/lib/data/repositories/chat/chat_repository_impl.dart
@@ -2,6 +2,7 @@ import 'package:ondo/data/models/base/request/base_list_request_model.dart';
 import 'package:ondo/data/models/chat/request/chat_message_list_request_model.dart';
 import 'package:ondo/data/models/chat/response/chat_message_model.dart';
 import 'package:ondo/data/models/chat/response/chat_model.dart';
+import 'package:ondo/domain/entities/base/pageable_wrapper.dart';
 import 'package:ondo/domain/entities/chat/chat_entity.dart';
 import 'package:ondo/domain/entities/chat/chat_message_entity.dart';
 import 'package:ondo/domain/repositories/chat/chat_repository.dart';
@@ -48,7 +49,7 @@ class ChatRepositoryImpl extends ChatRepository {
   }
 
   @override
-  Future<List<ChatMessageEntity>> loadChatRoomMessages(
+  Future<PageableWrapper<ChatMessageEntity>> loadChatRoomMessages(
     String chatRoomPublicId,
     int cursor,
     int size,
@@ -59,7 +60,7 @@ class ChatRepositoryImpl extends ChatRepository {
       model,
     );
 
-    if (json == null) return [];
+    if (json == null) return PageableWrapper(pages: [], nextCursor: null);
 
     final dataModelList =
         (json["items"] as List?)
@@ -69,15 +70,18 @@ class ChatRepositoryImpl extends ChatRepository {
             .toList() ??
         [];
 
-    return dataModelList
-        .map((e) => ChatMessageEntity.fromJsonChatMessageModel(e))
-        .toList();
+    return PageableWrapper(
+      pages: dataModelList
+          .map((e) => ChatMessageEntity.fromJsonChatMessageModel(e))
+          .toList(),
+      nextCursor: json["nextCursor"],
+    );
   }
 
   @override
   Future<bool> readChatMessage(
     String chatRoomPublicId,
-    num lastReadMessageId,
+    int lastReadMessageId,
   ) async {
     final res = await remoteDatasource.readChatMessage(
       chatRoomPublicId,

--- a/lib/domain/entities/base/pageable_wrapper.dart
+++ b/lib/domain/entities/base/pageable_wrapper.dart
@@ -1,0 +1,6 @@
+class PageableWrapper<T> {
+  final List<T> pages;
+  final int? nextCursor;
+
+  PageableWrapper({required this.pages, required this.nextCursor});
+}

--- a/lib/domain/entities/chat/chat_entity.dart
+++ b/lib/domain/entities/chat/chat_entity.dart
@@ -10,6 +10,7 @@ class ChatEntity {
   final String lastMessagePreview;
   final bool muted;
   final DateTime? lastMessageAt;
+  late bool read = unreadCount > 0;
 
   ChatEntity({
     required this.roomId,

--- a/lib/domain/repositories/chat/chat_repository.dart
+++ b/lib/domain/repositories/chat/chat_repository.dart
@@ -15,4 +15,6 @@ abstract class ChatRepository {
   Future<bool> blockChatRoom(String chatRoomPublicId);
 
   Future<bool> cancelBlockChatRoom(String chatRoomPublicId);
+
+  Future<bool> readChatMessage(String chatRoomPublicId, num lastReadMessageId);
 }

--- a/lib/domain/repositories/chat/chat_repository.dart
+++ b/lib/domain/repositories/chat/chat_repository.dart
@@ -1,10 +1,11 @@
+import 'package:ondo/domain/entities/base/pageable_wrapper.dart';
 import 'package:ondo/domain/entities/chat/chat_entity.dart';
 import 'package:ondo/domain/entities/chat/chat_message_entity.dart';
 
 abstract class ChatRepository {
   Future<List<ChatEntity>> loadMyChatRoomList(int size, int page);
 
-  Future<List<ChatMessageEntity>> loadChatRoomMessages(
+  Future<PageableWrapper<ChatMessageEntity>> loadChatRoomMessages(
     String chatRoomPublicId,
     int cursor,
     int size,
@@ -16,5 +17,5 @@ abstract class ChatRepository {
 
   Future<bool> cancelBlockChatRoom(String chatRoomPublicId);
 
-  Future<bool> readChatMessage(String chatRoomPublicId, num lastReadMessageId);
+  Future<bool> readChatMessage(String chatRoomPublicId, int lastReadMessageId);
 }

--- a/lib/domain/usecases/chat/load_chat_room_message_use_case.dart
+++ b/lib/domain/usecases/chat/load_chat_room_message_use_case.dart
@@ -1,3 +1,4 @@
+import 'package:ondo/domain/entities/base/pageable_wrapper.dart';
 import 'package:ondo/domain/entities/chat/chat_message_entity.dart';
 import 'package:ondo/domain/repositories/chat/chat_repository.dart';
 
@@ -6,7 +7,7 @@ class LoadChatRoomMessageUseCase {
 
   LoadChatRoomMessageUseCase({required this.repository});
 
-  Future<List<ChatMessageEntity>> call({
+  Future<PageableWrapper<ChatMessageEntity>> call({
     required String chatRoomPublicId,
     required int cursor,
     required int size,

--- a/lib/domain/usecases/chat/read_chat_message_use_case.dart
+++ b/lib/domain/usecases/chat/read_chat_message_use_case.dart
@@ -1,0 +1,14 @@
+import 'package:ondo/domain/repositories/chat/chat_repository.dart';
+
+class ReadChatMessageUseCase {
+  final ChatRepository repository;
+
+  ReadChatMessageUseCase({required this.repository});
+
+  Future<bool> call(String chatRoomPublicId, num lastReadMessageId) async {
+    return await repository.readChatMessage(
+      chatRoomPublicId,
+      lastReadMessageId,
+    );
+  }
+}

--- a/lib/domain/usecases/chat/read_chat_message_use_case.dart
+++ b/lib/domain/usecases/chat/read_chat_message_use_case.dart
@@ -5,7 +5,7 @@ class ReadChatMessageUseCase {
 
   ReadChatMessageUseCase({required this.repository});
 
-  Future<bool> call(String chatRoomPublicId, num lastReadMessageId) async {
+  Future<bool> call(String chatRoomPublicId, int lastReadMessageId) async {
     return await repository.readChatMessage(
       chatRoomPublicId,
       lastReadMessageId,

--- a/lib/presentation/chat/controllers/chat_main_controller.dart
+++ b/lib/presentation/chat/controllers/chat_main_controller.dart
@@ -50,13 +50,6 @@ class ChatMainController extends GetxController {
     }
   }
 
-  Future<void> _blockChatRoom(String chatRoomPublicId) async {
-    final success = await blockChatRoomUseCase.call(chatRoomPublicId);
-    if (success != true) {
-      error.value = "BLOCK_FAILED";
-    }
-  }
-
   Future<void> _readChatMessage(
     String chatRoomPublicId,
     num lastReadMessageId,

--- a/lib/presentation/chat/controllers/chat_main_controller.dart
+++ b/lib/presentation/chat/controllers/chat_main_controller.dart
@@ -4,7 +4,6 @@ import 'package:ondo/domain/entities/chat/chat_entity.dart';
 import 'package:ondo/domain/usecases/chat/block_chat_room_use_case.dart';
 import 'package:ondo/domain/usecases/chat/cancel_block_chat_room_use_case.dart';
 import 'package:ondo/domain/usecases/chat/load_my_chat_room_list_use_case.dart';
-import 'package:ondo/domain/usecases/chat/read_chat_message_use_case.dart';
 import 'package:ondo/presentation/chat/screens/chat_room_screen.dart';
 
 class ChatMainController extends GetxController {
@@ -20,13 +19,11 @@ class ChatMainController extends GetxController {
   final LoadMyChatRoomListUseCase loadChatRoomsUseCase;
   final BlockChatRoomUseCase blockChatRoomUseCase;
   final CancelBlockChatRoomUseCase cancelBlockChatRoomUseCase;
-  final ReadChatMessageUseCase readChatMessageUseCase;
 
   ChatMainController({
     required this.loadChatRoomsUseCase,
     required this.blockChatRoomUseCase,
     required this.cancelBlockChatRoomUseCase,
-    required this.readChatMessageUseCase,
   });
 
   @override
@@ -37,6 +34,7 @@ class ChatMainController extends GetxController {
   }
 
   Future<void> _loadChatRooms() async {
+    //TODO 구조 변경
     _cacheChatRoomList.assignAll(
       await loadChatRoomsUseCase.call(page: 0, size: 10),
     );
@@ -47,19 +45,6 @@ class ChatMainController extends GetxController {
     final success = await cancelBlockChatRoomUseCase.call(chatRoomPublicId);
     if (success != true) {
       error.value = "CANCEL_BLOCK_FAILED";
-    }
-  }
-
-  Future<void> _readChatMessage(
-    String chatRoomPublicId,
-    num lastReadMessageId,
-  ) async {
-    final success = await readChatMessageUseCase.call(
-      chatRoomPublicId,
-      lastReadMessageId,
-    );
-    if (success != true) {
-      error.value = "READ_FAILED";
     }
   }
 
@@ -106,14 +91,13 @@ class ChatMainController extends GetxController {
     //TODO : 웹소켓 연결, 채팅 방 접근에 대한 필요 정보를 전달히여 채팅 방 UI 생성
     final roomId = viewChatRoomList[index].roomId;
     //TODO : route 정의 이후에 방식 변경
-    final lastMessageId = await Get.to<num>(
-      ChatRoomScreen(roomId: roomId),
-      binding: ChatRoomBinding(chatRoomId: roomId)
-    );
-
-    if (lastMessageId == null) return;
-
-    _readChatMessage(roomId, lastMessageId);
+    viewChatRoomList[index].read =
+        await Get.to<bool>(
+          ChatRoomScreen(roomId: roomId),
+          binding: ChatRoomBinding(chatRoomId: roomId),
+        ) ??
+        false;
+    viewChatRoomList.refresh();
   }
 
   Future<void> blockingChat(int index) async {

--- a/lib/presentation/chat/controllers/chat_main_controller.dart
+++ b/lib/presentation/chat/controllers/chat_main_controller.dart
@@ -4,6 +4,7 @@ import 'package:ondo/domain/entities/chat/chat_entity.dart';
 import 'package:ondo/domain/usecases/chat/block_chat_room_use_case.dart';
 import 'package:ondo/domain/usecases/chat/cancel_block_chat_room_use_case.dart';
 import 'package:ondo/domain/usecases/chat/load_my_chat_room_list_use_case.dart';
+import 'package:ondo/domain/usecases/chat/read_chat_message_use_case.dart';
 import 'package:ondo/presentation/chat/screens/chat_room_screen.dart';
 
 class ChatMainController extends GetxController {
@@ -19,11 +20,13 @@ class ChatMainController extends GetxController {
   final LoadMyChatRoomListUseCase loadChatRoomsUseCase;
   final BlockChatRoomUseCase blockChatRoomUseCase;
   final CancelBlockChatRoomUseCase cancelBlockChatRoomUseCase;
+  final ReadChatMessageUseCase readChatMessageUseCase;
 
   ChatMainController({
     required this.loadChatRoomsUseCase,
     required this.blockChatRoomUseCase,
     required this.cancelBlockChatRoomUseCase,
+    required this.readChatMessageUseCase,
   });
 
   @override
@@ -44,6 +47,26 @@ class ChatMainController extends GetxController {
     final success = await cancelBlockChatRoomUseCase.call(chatRoomPublicId);
     if (success != true) {
       error.value = "CANCEL_BLOCK_FAILED";
+    }
+  }
+
+  Future<void> _blockChatRoom(String chatRoomPublicId) async {
+    final success = await blockChatRoomUseCase.call(chatRoomPublicId);
+    if (success != true) {
+      error.value = "BLOCK_FAILED";
+    }
+  }
+
+  Future<void> _readChatMessage(
+    String chatRoomPublicId,
+    num lastReadMessageId,
+  ) async {
+    final success = await readChatMessageUseCase.call(
+      chatRoomPublicId,
+      lastReadMessageId,
+    );
+    if (success != true) {
+      error.value = "READ_FAILED";
     }
   }
 
@@ -86,16 +109,18 @@ class ChatMainController extends GetxController {
     _filterChatRooms();
   }
 
-  void enterChatRoom(int index) {
+  Future<void> enterChatRoom(int index) async {
     //TODO : 웹소켓 연결, 채팅 방 접근에 대한 필요 정보를 전달히여 채팅 방 UI 생성
     final roomId = viewChatRoomList[index].roomId;
-    //TODO : Get.to 접근 보다는 GoRoute 기법 활용
-    Get.to(
-      ChatRoomScreen(
-        roomId: roomId,
-      ),
-      binding: ChatRoomBinding(chatRoomId: roomId),
+    //TODO : route 정의 이후에 방식 변경
+    final lastMessageId = await Get.to<num>(
+      ChatRoomScreen(roomId: roomId),
+      binding: ChatRoomBinding(chatRoomId: roomId)
     );
+
+    if (lastMessageId == null) return;
+
+    _readChatMessage(roomId, lastMessageId);
   }
 
   Future<void> blockingChat(int index) async {

--- a/lib/presentation/chat/controllers/chat_room_controller.dart
+++ b/lib/presentation/chat/controllers/chat_room_controller.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:ondo/core/design_system/components/custom_alert_dialog.dart';
 import 'package:ondo/domain/entities/chat/chat_message_entity.dart';
 import 'package:ondo/domain/usecases/chat/load_chat_room_message_use_case.dart';
+import 'package:ondo/domain/usecases/chat/read_chat_message_use_case.dart';
 import 'package:ondo/presentation/chat/controllers/chat_review_controller.dart';
 import 'package:ondo/presentation/chat/view_models/chat_message_view_model.dart';
 import 'package:ondo/presentation/chat/widgets/chat_review_dialog.dart';
@@ -16,31 +17,42 @@ class ChatRoomController extends GetxController {
   final String chatRoomId;
 
   final LoadChatRoomMessageUseCase loadChatRoomMessageUseCase;
+  final ReadChatMessageUseCase readChatMessageUseCase;
+
+  int lastMessageId = 0;
 
   ChatRoomController({
     required this.chatRoomId,
     required this.loadChatRoomMessageUseCase,
+    required this.readChatMessageUseCase,
   });
 
   @override
   void onInit() {
-    _loadChatRoomMessages();
+    _initLoadChatRoomMessages();
     super.onInit();
   }
 
-  Future<void> _loadChatRoomMessages() async {
-    //TODO : 정적 데이터 삭제
-    final messages = await loadChatRoomMessageUseCase.call(
-      chatRoomPublicId: chatRoomId,
-      cursor: 0,
-      size: 20,
-    );
-    _cacheChatList.assignAll(messages);
-    viewChatList.assignAll(
-      _cacheChatList.map(
-        (e) => ChatMessageViewModel.fromJsonChatMessageEntity(e),
-      ),
-    );
+  Future _initLoadChatRoomMessages() async {
+    int? next = 0;
+    while (next != null) {
+      final res = await loadChatRoomMessageUseCase.call(
+        chatRoomPublicId: chatRoomId,
+        cursor: next,
+        size: 10,
+      );
+      _cacheChatList.addAll(res.pages);
+      next = res.nextCursor;
+    }
+
+    if (_cacheChatList.isNotEmpty) {
+      viewChatList.assignAll(
+        _cacheChatList.reversed.map(
+          (e) => ChatMessageViewModel.fromJsonChatMessageEntity(e),
+        ),
+      );
+      lastMessageId = _cacheChatList.last.messageId;
+    }
   }
 
   void sendChat(String content) {
@@ -58,7 +70,13 @@ class ChatRoomController extends GetxController {
     );
   }
 
-  void showQuitAlert() {
+  Future backChatRoom() async {
+    Get.back<bool>(
+      result: await readChatMessageUseCase.call(chatRoomId, lastMessageId),
+    );
+  }
+
+  void quitChatRoom() {
     Get.dialog(
       CustomAlertDialog(
         title: "커피챗 종료",

--- a/lib/presentation/chat/screens/chat_room_screen.dart
+++ b/lib/presentation/chat/screens/chat_room_screen.dart
@@ -86,6 +86,7 @@ class ChatRoomScreen extends GetView<ChatRoomController> {
   Widget _topBar() => CustomBackButton(
     moreOptions: true,
     useUserProfile: true,
+    backAction: controller.backChatRoom,
     userInfo: (
       SvgPicture.asset(
         AppIcon.defaultProfile.path,
@@ -95,12 +96,12 @@ class ChatRoomScreen extends GetView<ChatRoomController> {
     itemBuilder: (context) => [
       _customPopupMenu(
         "커피챗 종료하기",
-        //종료 알림창 표시
-        controller.showQuitAlert,
+
+        ///종료 알림창 표시
+        controller.quitChatRoom,
       ),
       _customPopupMenu(
         "신고하기",
-        //신고 기능
         () {
           //TODO : 신고 기능
         },


### PR DESCRIPTION
## 📌 개요

채팅 방 메세지 읽음 처리를 위한 API를 연동합니다.

---

## 🧩 작업 내용

- [x]  ChatRemoteDatasource에 readChatMessage() 함수 추가
- [x]  ChatRepository, ChatRepositoryImpl에 관련 로직 추가
- [x]  ReadChatMessageUseCase 정의
- [x]  ChatMainController와 연동

---

## 📎 참고 사항


- API 명세 /chat 참고
- close #135 