### PR TITLE
[FEATURE] WebSocket STOMP 연결/해제 구현

### DIFF
--- a/lib/core/router/bindings/chat_binding.dart
+++ b/lib/core/router/bindings/chat_binding.dart
@@ -1,5 +1,6 @@
 import 'package:get/get.dart';
 import 'package:ondo/data/datasource/chat/chat_remote_datasource.dart';
+import 'package:ondo/data/network/websocket/chat_stomp_client.dart';
 import 'package:ondo/data/repositories/chat/chat_repository_impl.dart';
 import 'package:ondo/domain/usecases/chat/block_chat_room_use_case.dart';
 import 'package:ondo/domain/usecases/chat/cancel_block_chat_room_use_case.dart';
@@ -7,11 +8,19 @@ import 'package:ondo/domain/usecases/chat/create_chat_room_use_case.dart';
 import 'package:ondo/domain/usecases/chat/load_my_chat_room_list_use_case.dart';
 import 'package:ondo/presentation/chat/controllers/chat_main_controller.dart';
 
+import '../../../data/datasource/base/auth_local_datasource.dart';
 import '../../../data/network/clients/auth_client.dart';
 
 class ChatBinding extends Bindings {
   @override
   void dependencies() {
+    /// STOMP 클라이언트 싱글톤 등록
+    /// fenix: true → 화면 이탈 후에도 인스턴스 유지/재생성 가능
+    Get.lazyPut<ChatStompClient>(
+      () => ChatStompClient(localDatasource: Get.find<AuthLocalDatasource>()),
+      fenix: true,
+    );
+
     ///chat 관련 dataSource 등록
     Get.lazyPut<ChatRemoteDatasource>(
       () => ChatRemoteDatasource(client: Get.find<AuthClient>()),

--- a/lib/data/network/websocket/chat_stomp_client.dart
+++ b/lib/data/network/websocket/chat_stomp_client.dart
@@ -1,0 +1,244 @@
+import 'dart:async';
+import 'dart:developer';
+
+import 'package:ondo/core/env.dart';
+import 'package:ondo/data/datasource/base/auth_local_datasource.dart';
+import 'package:ondo/data/network/websocket/stomp_frame.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// STOMP over WebSocket 클라이언트
+///
+/// 역할:
+/// - JWT 인증 헤더를 포함한 STOMP CONNECT 처리
+/// - 토픽 구독(subscribe) / 발행(publish) 관리
+/// - 연결 실패 시 자동 재연결 (최대 [_maxReconnectAttempts]회)
+/// - 앱 포그라운드/백그라운드에 따른 Ping 일시 중단/재개
+class ChatStompClient {
+  final AuthLocalDatasource _localDatasource;
+
+  ChatStompClient({required AuthLocalDatasource localDatasource})
+      : _localDatasource = localDatasource;
+
+  // ─── WebSocket ────────────────────────────────────────
+  WebSocketChannel? _channel;
+  StreamSubscription? _streamSubscription;
+  bool _isConnected = false;
+
+  bool get isConnected => _isConnected;
+
+  // ─── 구독 관리 ─────────────────────────────────────────
+  /// subscriptionId → callback
+  final Map<String, void Function(StompFrame)> _subscriptions = {};
+  int _subscriptionCounter = 0;
+
+  // ─── 재연결 ───────────────────────────────────────────
+  Timer? _reconnectTimer;
+  int _reconnectAttempts = 0;
+  static const int _maxReconnectAttempts = 5;
+  static const Duration _reconnectInterval = Duration(seconds: 3);
+
+  // ─── Ping ─────────────────────────────────────────────
+  Timer? _pingTimer;
+  bool _isPaused = false;
+  static const Duration _pingInterval = Duration(seconds: 30);
+
+  // ─── Public API ───────────────────────────────────────
+
+  /// WebSocket 연결 및 STOMP CONNECT 전송
+  ///
+  /// 이미 연결된 경우 무시.
+  /// 토큰이 없으면 연결하지 않음.
+  Future<void> connect() async {
+    if (_isConnected) return;
+
+    final token = await _localDatasource.getAccessToken();
+    if (token == null) {
+      log('[STOMP] 토큰 없음 → 연결 취소');
+      return;
+    }
+
+    try {
+      final wsUrl = Env.wsBaseUrl;
+      log('[STOMP] 연결 시도: $wsUrl');
+
+      _channel = WebSocketChannel.connect(Uri.parse(wsUrl));
+
+      _streamSubscription = _channel!.stream.listen(
+        _onMessage,
+        onError: _onError,
+        onDone: _onDone,
+        cancelOnError: false,
+      );
+
+      _sendFrame(StompFrame(
+        command: 'CONNECT',
+        headers: {
+          'accept-version': '1.1,1.2',
+          'Authorization': 'Bearer $token',
+        },
+      ));
+      log('[STOMP] CONNECT 프레임 전송');
+    } catch (e) {
+      log('[STOMP] 연결 실패: $e');
+      _scheduleReconnect();
+    }
+  }
+
+  /// 토픽 구독
+  ///
+  /// [destination] 예: `/topic/chat.rooms.{chatRoomPublicId}`
+  /// 반환값: subscriptionId (unsubscribe 시 사용)
+  String subscribe(String destination, void Function(StompFrame) onFrame) {
+    final id = 'sub-${_subscriptionCounter++}';
+    _subscriptions[id] = onFrame;
+
+    _sendFrame(StompFrame(
+      command: 'SUBSCRIBE',
+      headers: {
+        'destination': destination,
+        'id': id,
+      },
+    ));
+    log('[STOMP] SUBSCRIBE → $destination (id: $id)');
+    return id;
+  }
+
+  /// 구독 해제
+  void unsubscribe(String subscriptionId) {
+    _subscriptions.remove(subscriptionId);
+    _sendFrame(StompFrame(
+      command: 'UNSUBSCRIBE',
+      headers: {'id': subscriptionId},
+    ));
+    log('[STOMP] UNSUBSCRIBE → id: $subscriptionId');
+  }
+
+  /// 메시지 발행
+  ///
+  /// [destination] 예: `/pub/chat.send`
+  /// [body] JSON 문자열. null이면 바디 없음.
+  void publish(String destination, {String? body}) {
+    if (!_isConnected) {
+      log('[STOMP] 연결 안 됨 → publish 무시: $destination');
+      return;
+    }
+    _sendFrame(StompFrame(
+      command: 'SEND',
+      headers: {
+        'destination': destination,
+        if (body != null) 'content-type': 'application/json',
+      },
+      body: body,
+    ));
+    log('[STOMP] SEND → $destination');
+  }
+
+  /// 연결 해제 및 모든 상태 초기화
+  void disconnect() {
+    _stopPing();
+    _reconnectTimer?.cancel();
+    _reconnectAttempts = 0;
+
+    if (_isConnected) {
+      _sendFrame(StompFrame(command: 'DISCONNECT'));
+    }
+
+    _streamSubscription?.cancel();
+    _channel?.sink.close();
+    _channel = null;
+    _isConnected = false;
+    _subscriptions.clear();
+    log('[STOMP] 연결 해제 완료');
+  }
+
+  /// 앱 백그라운드 진입 시 호출 → Ping 중단
+  void pausePing() {
+    _isPaused = true;
+    _stopPing();
+    log('[STOMP] Ping 일시 중단 (백그라운드)');
+  }
+
+  /// 앱 포그라운드 복귀 시 호출 → Ping 재개 (필요 시 재연결)
+  void resumePing() {
+    _isPaused = false;
+    if (_isConnected) {
+      _startPing();
+    } else {
+      log('[STOMP] 포그라운드 복귀 → 재연결 시도');
+      connect();
+    }
+    log('[STOMP] Ping 재개 (포그라운드)');
+  }
+
+  // ─── 내부 ─────────────────────────────────────────────
+
+  void _sendFrame(StompFrame frame) {
+    _channel?.sink.add(frame.serialize());
+  }
+
+  void _onMessage(dynamic raw) {
+    if (raw is! String) return;
+
+    final frame = StompFrame.parse(raw);
+    if (frame == null) return; // heartbeat
+
+    log('[STOMP] 수신: ${frame.command}');
+
+    switch (frame.command) {
+      case 'CONNECTED':
+        _isConnected = true;
+        _reconnectAttempts = 0;
+        if (!_isPaused) _startPing();
+        log('[STOMP] 연결 성공');
+
+      case 'MESSAGE':
+        final subId = frame.headers['subscription'];
+        if (subId != null) {
+          _subscriptions[subId]?.call(frame);
+        }
+
+      case 'ERROR':
+        log('[STOMP] 서버 에러: ${frame.headers} / ${frame.body}');
+    }
+  }
+
+  void _onError(Object error) {
+    log('[STOMP] WebSocket 에러: $error');
+    _isConnected = false;
+    _stopPing();
+    _scheduleReconnect();
+  }
+
+  void _onDone() {
+    log('[STOMP] WebSocket 연결 종료');
+    _isConnected = false;
+    _stopPing();
+    if (!_isPaused) _scheduleReconnect();
+  }
+
+  void _scheduleReconnect() {
+    if (_reconnectAttempts >= _maxReconnectAttempts) {
+      log('[STOMP] 최대 재연결 횟수($_maxReconnectAttempts) 초과 → 중단');
+      return;
+    }
+    _reconnectTimer?.cancel();
+    _reconnectTimer = Timer(_reconnectInterval, () {
+      _reconnectAttempts++;
+      log('[STOMP] 재연결 시도 $_reconnectAttempts/$_maxReconnectAttempts');
+      connect();
+    });
+  }
+
+  void _startPing() {
+    _stopPing();
+    _pingTimer = Timer.periodic(_pingInterval, (_) {
+      publish('/pub/chat.ping');
+      log('[STOMP] Ping 전송');
+    });
+  }
+
+  void _stopPing() {
+    _pingTimer?.cancel();
+    _pingTimer = null;
+  }
+}

--- a/lib/data/network/websocket/stomp_frame.dart
+++ b/lib/data/network/websocket/stomp_frame.dart
@@ -1,0 +1,76 @@
+/// STOMP 프레임 직렬화 / 역직렬화 유틸리티
+///
+/// STOMP 프레임 포맷:
+/// ```
+/// COMMAND\n
+/// header1:value1\n
+/// header2:value2\n
+/// \n
+/// body\0
+/// ```
+class StompFrame {
+  final String command;
+  final Map<String, String> headers;
+  final String? body;
+
+  const StompFrame({
+    required this.command,
+    this.headers = const {},
+    this.body,
+  });
+
+  /// 프레임 → String (서버로 전송)
+  String serialize() {
+    final buffer = StringBuffer();
+    buffer.write('$command\n');
+    for (final entry in headers.entries) {
+      buffer.write('${entry.key}:${entry.value}\n');
+    }
+    buffer.write('\n');
+    if (body != null) {
+      buffer.write(body);
+    }
+    buffer.write('\x00');
+    return buffer.toString();
+  }
+
+  /// String → StompFrame (서버에서 수신)
+  static StompFrame? parse(String raw) {
+    // 빈 heartbeat 프레임 무시
+    if (raw.isEmpty || raw == '\n' || raw == '\x00') return null;
+
+    // 헤더 섹션과 바디 섹션을 \n\n 기준으로 분리
+    final headerBodySplit = raw.split('\n\n');
+    if (headerBodySplit.isEmpty) return null;
+
+    final headerSection = headerBodySplit[0];
+
+    // 바디: \n\n 이후 전체, null terminator 제거
+    String? body;
+    if (headerBodySplit.length > 1) {
+      final rawBody = headerBodySplit.sublist(1).join('\n\n').replaceAll('\x00', '').trim();
+      body = rawBody.isEmpty ? null : rawBody;
+    }
+
+    final lines = headerSection.split('\n');
+    if (lines.isEmpty) return null;
+
+    final command = lines[0].trim();
+    if (command.isEmpty) return null;
+
+    final headers = <String, String>{};
+    for (int i = 1; i < lines.length; i++) {
+      final line = lines[i].trim();
+      if (line.isEmpty) continue;
+      final colonIndex = line.indexOf(':');
+      if (colonIndex == -1) continue;
+      headers[line.substring(0, colonIndex).trim()] =
+          line.substring(colonIndex + 1).trim();
+    }
+
+    return StompFrame(command: command, headers: headers, body: body);
+  }
+
+  @override
+  String toString() => 'StompFrame(command: $command, headers: $headers)';
+}


### PR DESCRIPTION
## 📌 개요
web_socket_channel 패키지를 활용하여 STOMP over WebSocket 연결 및 해제를 구현한다.
JWT 인증 헤더 포함 및 자동 재연결, Ping 관리 기능을 포함한다.

## 🧩 작업 내용
- [x] StompFrame: STOMP 프레임 직렬화/역직렬화 유틸 추가
- [x] ChatStompClient: web_socket_channel 기반 STOMP 클라이언트 구현
  - [x] JWT Authorization 헤더 포함 CONNECT 처리
  - [x] 구독(subscribe) / 발행(publish) / 해제(unsubscribe) 지원
  - [x] 연결 실패 시 자동 재연결 (3초 간격, 최대 5회)
  - [x] 앱 포그라운드/백그라운드에 따른 Ping 일시 중단/재개 (30초 주기)
- [x] ChatBinding: ChatStompClient 싱글톤 DI 등록 (fenix: true)

## 📎 참고 사항
- Endpoint: ws://{host}/ws
- Protocol: STOMP over WebSocket
- 패키지: web_socket_channel ^3.0.3

close #161