### PR TITLE
[FEATURE] 읽은 알림 전체 삭제 API 연동

### DIFF
--- a/lib/core/router/bindings/notification_binding.dart
+++ b/lib/core/router/bindings/notification_binding.dart
@@ -2,6 +2,7 @@ import 'package:get/get.dart';
 import 'package:ondo/data/datasource/notification/notification_remote_datasource.dart';
 import 'package:ondo/data/network/clients/auth_client.dart';
 import 'package:ondo/data/repositories/notification/notification_repository_impl.dart';
+import 'package:ondo/domain/usecases/notification/delete_all_read_notifications_use_case.dart';
 import 'package:ondo/domain/usecases/notification/load_my_notification_list_use_case.dart';
 import 'package:ondo/domain/usecases/notification/load_unread_notification_count_use_case.dart';
 import 'package:ondo/domain/usecases/notification/read_all_notification_use_case.dart';
@@ -47,10 +48,17 @@ class NotificationBinding extends Bindings {
         repository: Get.find<NotificationRepositoryImpl>(),
       ),
     );
+    Get.lazyPut<DeleteAllReadNotificationsUseCase>(
+      () => DeleteAllReadNotificationsUseCase(
+        repository: Get.find<NotificationRepositoryImpl>(),
+      ),
+    );
 
     ///notification controller 등록
     Get.lazyPut<NotificationController>(
       () => NotificationController(
+        deleteAllReadNotificationsUseCase:
+            Get.find<DeleteAllReadNotificationsUseCase>(),
         readNotificationUseCase: Get.find<ReadNotificationUseCase>(),
         readAllNotificationUseCase: Get.find<ReadAllNotificationUseCase>(),
         loadMyNotificationListUseCase:

--- a/lib/data/datasource/notification/notification_remote_datasource.dart
+++ b/lib/data/datasource/notification/notification_remote_datasource.dart
@@ -94,7 +94,7 @@ class NotificationRemoteDatasource {
       log.successLog(body["success"]);
       log.messageLog(body["message"]);
 
-      if (res.statusCode == 200) {
+      if (res.statusCode == 200 && body["success"] == true) {
         return true;
       }
 

--- a/lib/data/datasource/notification/notification_remote_datasource.dart
+++ b/lib/data/datasource/notification/notification_remote_datasource.dart
@@ -81,6 +81,30 @@ class NotificationRemoteDatasource {
     return null;
   }
 
+  Future<bool> deleteAllReadNotifications() async {
+    final log = ApiConstants(logName: "읽은 알림 전체 삭제");
+
+    try {
+      final res = await client.delete(
+        Uri.parse("${ApiConstants.notification}/read"),
+      );
+
+      final body = jsonDecode(res.body);
+
+      log.successLog(body["success"]);
+      log.messageLog(body["message"]);
+
+      if (res.statusCode == 200) {
+        return true;
+      }
+
+      log.statusLog(res.statusCode);
+    } catch (e) {
+      log.errorLog(e);
+    }
+    return false;
+  }
+
   Future<bool> readNotification(int id) async {
     final log = ApiConstants(logName: "단건 알림 읽음 처리");
 

--- a/lib/data/repositories/notification/notification_repository_impl.dart
+++ b/lib/data/repositories/notification/notification_repository_impl.dart
@@ -52,4 +52,10 @@ class NotificationRepositoryImpl extends NotificationRepository {
   Future<bool> readNotification(int id) {
     return remoteDatasource.readNotification(id);
   }
+
+  @override
+  Future<bool> deleteAllReadNotifications() async {
+    final res = await remoteDatasource.deleteAllReadNotifications();
+    return res;
+  }
 }

--- a/lib/domain/repositories/notification/notification_repository.dart
+++ b/lib/domain/repositories/notification/notification_repository.dart
@@ -9,4 +9,5 @@ abstract class NotificationRepository {
 
   Future<bool> readNotification(int id);
 
+  Future<bool> deleteAllReadNotifications();
 }

--- a/lib/domain/usecases/notification/delete_all_read_notifications_use_case.dart
+++ b/lib/domain/usecases/notification/delete_all_read_notifications_use_case.dart
@@ -1,0 +1,11 @@
+import 'package:ondo/domain/repositories/notification/notification_repository.dart';
+
+class DeleteAllReadNotificationsUseCase {
+  final NotificationRepository repository;
+
+  DeleteAllReadNotificationsUseCase({required this.repository});
+
+  Future<bool> call() async {
+    return repository.deleteAllReadNotifications();
+  }
+}

--- a/lib/presentation/notification/controllers/notification_controller.dart
+++ b/lib/presentation/notification/controllers/notification_controller.dart
@@ -33,23 +33,23 @@ class NotificationController extends GetxController {
     super.onInit();
   }
 
-  Future _loadMyNotificationList() async {
+  Future<void> _loadMyNotificationList() async {
     //TODO : 화면 연동 과정에서 범위 맞추기
     viewNotificationList.assignAll(
       await loadMyNotificationListUseCase.call(size: 20, page: 0),
     );
   }
 
-  Future _loadUnreadNotificationCount() async {
+  Future<void> _loadUnreadNotificationCount() async {
     newNotificationCount.value = await loadUnreadNotificationCountUseCase
         .call();
   }
 
-  Future _readAllNotification() async {
+  Future<void> _readAllNotification() async {
     await readAllNotificationUseCase.call();
   }
 
-  Future _readNotification(int id) async {
+  Future<bool> _readNotification(int id) async {
     return await readNotificationUseCase.call(id);
   }
 
@@ -57,7 +57,7 @@ class NotificationController extends GetxController {
     return deleteAllReadNotificationsUseCase.call();
   }
 
-  Future read(NotificationEntity notification) async {
+  Future<void> read(NotificationEntity notification) async {
     if (await _readNotification(notification.id)) {
       final index = viewNotificationList.indexWhere(
         (e) => e.id == notification.id,
@@ -68,7 +68,7 @@ class NotificationController extends GetxController {
     }
   }
 
-  Future readAll() async {
+  Future<void> readAll() async {
     await _readAllNotification();
     viewNotificationList.assignAll(
       viewNotificationList.map((e) => e.copyWith(read: true)),
@@ -76,7 +76,7 @@ class NotificationController extends GetxController {
     newNotificationCount.value = 0;
   }
 
-  Future clear() async {
+  Future<void> clear() async {
     if (await _deleteAllReadNotification()) {
       viewNotificationList.removeWhere(
         (notification) => notification.read == true,

--- a/lib/presentation/notification/controllers/notification_controller.dart
+++ b/lib/presentation/notification/controllers/notification_controller.dart
@@ -1,5 +1,6 @@
 import 'package:get/get.dart';
 import 'package:ondo/domain/entities/notification/notification_entity.dart';
+import 'package:ondo/domain/usecases/notification/delete_all_read_notifications_use_case.dart';
 import 'package:ondo/domain/usecases/notification/load_my_notification_list_use_case.dart';
 import 'package:ondo/domain/usecases/notification/load_unread_notification_count_use_case.dart';
 import 'package:ondo/domain/usecases/notification/read_all_notification_use_case.dart';
@@ -15,12 +16,14 @@ class NotificationController extends GetxController {
   final LoadUnreadNotificationCountUseCase loadUnreadNotificationCountUseCase;
   final ReadAllNotificationUseCase readAllNotificationUseCase;
   final ReadNotificationUseCase readNotificationUseCase;
+  final DeleteAllReadNotificationsUseCase deleteAllReadNotificationsUseCase;
 
   NotificationController({
     required this.loadMyNotificationListUseCase,
     required this.loadUnreadNotificationCountUseCase,
     required this.readAllNotificationUseCase,
     required this.readNotificationUseCase,
+    required this.deleteAllReadNotificationsUseCase,
   });
 
   @override
@@ -30,27 +33,31 @@ class NotificationController extends GetxController {
     super.onInit();
   }
 
-  Future<void> _loadMyNotificationList() async {
+  Future _loadMyNotificationList() async {
     //TODO : 화면 연동 과정에서 범위 맞추기
     viewNotificationList.assignAll(
       await loadMyNotificationListUseCase.call(size: 20, page: 0),
     );
   }
 
-  Future<void> _loadUnreadNotificationCount() async {
+  Future _loadUnreadNotificationCount() async {
     newNotificationCount.value = await loadUnreadNotificationCountUseCase
         .call();
   }
 
-  Future<void> _readAllNotification() async {
+  Future _readAllNotification() async {
     await readAllNotificationUseCase.call();
   }
 
-  Future<bool> _readNotification(int id) async {
+  Future _readNotification(int id) async {
     return await readNotificationUseCase.call(id);
   }
 
-  Future<void> read(NotificationEntity notification) async {
+  Future<bool> _deleteAllReadNotification() async {
+    return deleteAllReadNotificationsUseCase.call();
+  }
+
+  Future read(NotificationEntity notification) async {
     if (await _readNotification(notification.id)) {
       final index = viewNotificationList.indexWhere(
         (e) => e.id == notification.id,
@@ -61,7 +68,7 @@ class NotificationController extends GetxController {
     }
   }
 
-  Future<void> readAll() async {
+  Future readAll() async {
     await _readAllNotification();
     viewNotificationList.assignAll(
       viewNotificationList.map((e) => e.copyWith(read: true)),
@@ -69,8 +76,11 @@ class NotificationController extends GetxController {
     newNotificationCount.value = 0;
   }
 
-  void clear() {
-    //TODO : 읽은 알림 모두 삭제 api 개발
-    viewNotificationList.removeWhere((element) => element.read == true);
+  Future clear() async {
+    if (await _deleteAllReadNotification()) {
+      viewNotificationList.removeWhere(
+        (notification) => notification.read == true,
+      );
+    }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -436,10 +436,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -745,10 +745,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## 📌 개요

읽은 전체 알림 삭제 기능을 위한 읽은 알림 전체 삭제 API를 연동

---

## 🧩 작업 내용

- [x] NotificationRemoteDatasource, NotificationRepository 관련 로직 추가
- [x] DeleteAllReadNotificationsUseCase 정의
- [x] NotificationController 연결

---

## 📎 참고 사항

- API 명세 /notification 참고
- close #187 