### PR TITLE
[FEATURE] WebSocket 재연결 후 구독 재등록

### DIFF
--- a/lib/data/network/websocket/chat_stomp_client.dart
+++ b/lib/data/network/websocket/chat_stomp_client.dart
@@ -198,13 +198,16 @@ class ChatStompClient {
 
     switch (frame.command) {
       case 'CONNECTED':
-        _isConnected = true;
-        _reconnectAttempts = 0;
-        if (!_isPaused) _startPing();
-        _resubscribeAll();
-        _connectCompleter?.complete();
-        _connectCompleter = null;
-        log('[STOMP] 연결 성공');
+        try {
+          _isConnected = true;
+          _reconnectAttempts = 0;
+          if (!_isPaused) _startPing();
+          _resubscribeAll();
+        } finally {
+          _connectCompleter?.complete();
+          _connectCompleter = null;
+          log('[STOMP] 연결 성공');
+        }
 
       case 'MESSAGE':
         final subId = frame.headers['subscription'];

--- a/lib/data/network/websocket/chat_stomp_client.dart
+++ b/lib/data/network/websocket/chat_stomp_client.dart
@@ -30,8 +30,9 @@ class ChatStompClient {
   bool get isConnected => _isConnected;
 
   // ─── 구독 관리 ─────────────────────────────────────────
-  /// subscriptionId → callback
-  final Map<String, void Function(StompFrame)> _subscriptions = {};
+  /// subscriptionId → (destination, callback)
+  final Map<String, ({String destination, void Function(StompFrame) callback})>
+  _subscriptions = {};
   int _subscriptionCounter = 0;
 
   // ─── 재연결 ───────────────────────────────────────────
@@ -101,7 +102,7 @@ class ChatStompClient {
   /// 반환값: subscriptionId (unsubscribe 시 사용)
   String subscribe(String destination, void Function(StompFrame) onFrame) {
     final id = 'sub-${_subscriptionCounter++}';
-    _subscriptions[id] = onFrame;
+    _subscriptions[id] = (destination: destination, callback: onFrame);
 
     _sendFrame(StompFrame(
       command: 'SUBSCRIBE',
@@ -200,6 +201,7 @@ class ChatStompClient {
         _isConnected = true;
         _reconnectAttempts = 0;
         if (!_isPaused) _startPing();
+        _resubscribeAll();
         _connectCompleter?.complete();
         _connectCompleter = null;
         log('[STOMP] 연결 성공');
@@ -207,7 +209,7 @@ class ChatStompClient {
       case 'MESSAGE':
         final subId = frame.headers['subscription'];
         if (subId != null) {
-          _subscriptions[subId]?.call(frame);
+          _subscriptions[subId]?.callback(frame);
         }
 
       case 'ERROR':
@@ -251,6 +253,21 @@ class ChatStompClient {
       log('[STOMP] 재연결 시도 $_reconnectAttempts/$_maxReconnectAttempts');
       connect();
     });
+  }
+
+  /// 재연결 후 기존 구독 목록을 서버에 재등록
+  void _resubscribeAll() {
+    if (_subscriptions.isEmpty) return;
+    for (final entry in _subscriptions.entries) {
+      _sendFrame(StompFrame(
+        command: 'SUBSCRIBE',
+        headers: {
+          'destination': entry.value.destination,
+          'id': entry.key,
+        },
+      ));
+      log('[STOMP] 재구독 → ${entry.value.destination} (id: ${entry.key})');
+    }
   }
 
   void _startPing() {


### PR DESCRIPTION
## 📌 개요

WebSocket 재연결 후 기존 구독(subscribe)이 서버에 재등록되지 않아 메시지를 수신하지 못하는 문제를 해결합니다.

---

## 🧩 작업 내용

- [x]  `_subscriptions`에 callback만 저장하던 구조를 `(destination, callback)` 형태로 변경
- [x]  `CONNECTED` 수신 시 `_resubscribeAll()` 호출하여 기존 구독 목록 서버에 재등록
- [x]  `_resubscribeAll()` 메서드 추가

---

## 📎 참고 사항

- 재연결은 기존 `_scheduleReconnect()` 로직에서 처리되며, 이번 작업은 재연결 성공 후 구독 복구에만 집중
- 변경 파일: `chat_stomp_client.dart` 1개

close: #219 