### PR TITLE
[FIX] 채팅 메시지 hasNext 적용

### DIFF
--- a/lib/presentation/chat/controllers/chat_room_controller.dart
+++ b/lib/presentation/chat/controllers/chat_room_controller.dart
@@ -99,7 +99,8 @@ class ChatRoomController extends GetxController {
   }
 
   void _onScroll() {
-    // ListView가 역순(최신 메시지가 아래)이므로 maxScrollExtent 근처 = 가장 오래된 메시지 쪽
+    if (!scrollController.hasClients) return;
+    // reverse: true 환경에서 maxScrollExtent 근처 = 가장 오래된 메시지 쪽
     if (scrollController.position.pixels >=
         scrollController.position.maxScrollExtent - 200) {
       loadMoreMessages();
@@ -379,11 +380,11 @@ class ChatRoomController extends GetxController {
 
     if (_cacheChatList.isNotEmpty) {
       viewChatList.assignAll(
-        _cacheChatList.reversed.map(
+        _cacheChatList.map(
           (e) => ChatMessageViewModel.fromJsonChatMessageEntity(e),
         ),
       );
-      lastMessageId = _cacheChatList.last.messageId;
+      lastMessageId = _cacheChatList.first.messageId;
     }
   }
 
@@ -403,7 +404,7 @@ class ChatRoomController extends GetxController {
       _nextCursor = res.nextCursor;
 
       viewChatList.assignAll(
-        _cacheChatList.reversed.map(
+        _cacheChatList.map(
           (e) => ChatMessageViewModel.fromJsonChatMessageEntity(e),
         ),
       );

--- a/lib/presentation/chat/controllers/chat_room_controller.dart
+++ b/lib/presentation/chat/controllers/chat_room_controller.dart
@@ -24,6 +24,7 @@ class ChatRoomController extends GetxController {
   final RxList<ChatMessageViewModel> viewChatList =
       <ChatMessageViewModel>[].obs;
   final TextEditingController textController = TextEditingController();
+  final ScrollController scrollController = ScrollController();
 
   /// 상대방이 마지막으로 읽은 메시지 ID (읽음 이벤트 수신 시 갱신)
   final RxInt opponentLastReadMessageId = 0.obs;
@@ -49,6 +50,10 @@ class ChatRoomController extends GetxController {
   String? _myPublicId;
 
   int lastMessageId = 0;
+
+  int? _nextCursor;
+  bool _hasNext = false;
+  bool _isLoadingMore = false;
 
   /// /topic/chat.rooms.{chatRoomPublicId} 구독 ID
   String? _messageSubscriptionId;
@@ -81,7 +86,6 @@ class ChatRoomController extends GetxController {
 
   @override
   void onInit() {
-    // 내 publicId 로드 → 메시지 내역 로드 → 읽음 처리 → WebSocket 구독 순서 보장
     authLocalDatasource.getMyPublicId().then((id) {
       _myPublicId = id;
       log('[ChatRoom] myPublicId: $_myPublicId');
@@ -90,7 +94,16 @@ class ChatRoomController extends GetxController {
       sendReadEvent();
       _connectAndEnter();
     });
+    scrollController.addListener(_onScroll);
     super.onInit();
+  }
+
+  void _onScroll() {
+    // ListView가 역순(최신 메시지가 아래)이므로 maxScrollExtent 근처 = 가장 오래된 메시지 쪽
+    if (scrollController.position.pixels >=
+        scrollController.position.maxScrollExtent - 200) {
+      loadMoreMessages();
+    }
   }
 
   @override
@@ -126,6 +139,7 @@ class ChatRoomController extends GetxController {
       body: jsonEncode({'chatRoomPublicId': chatRoomId}),
     );
     textController.dispose();
+    scrollController.dispose();
     super.onClose();
   }
 
@@ -354,18 +368,14 @@ class ChatRoomController extends GetxController {
   }
 
   Future _initLoadChatRoomMessages() async {
-    int? cursor = 0;
-    bool hasNext = true;
-    while (hasNext && cursor != null) {
-      final res = await loadChatRoomMessageUseCase.call(
-        chatRoomPublicId: chatRoomId,
-        cursor: cursor,
-        size: 50,
-      );
-      _cacheChatList.addAll(res.pages);
-      hasNext = res.hasNext;
-      cursor = res.nextCursor;
-    }
+    final res = await loadChatRoomMessageUseCase.call(
+      chatRoomPublicId: chatRoomId,
+      cursor: 0,
+      size: 50,
+    );
+    _cacheChatList.addAll(res.pages);
+    _hasNext = res.hasNext;
+    _nextCursor = res.nextCursor;
 
     if (_cacheChatList.isNotEmpty) {
       viewChatList.assignAll(
@@ -374,6 +384,31 @@ class ChatRoomController extends GetxController {
         ),
       );
       lastMessageId = _cacheChatList.last.messageId;
+    }
+  }
+
+  /// 스크롤 상단 도달 시 이전 메시지 추가 로드
+  Future<void> loadMoreMessages() async {
+    if (!_hasNext || _nextCursor == null || _isLoadingMore) return;
+
+    _isLoadingMore = true;
+    try {
+      final res = await loadChatRoomMessageUseCase.call(
+        chatRoomPublicId: chatRoomId,
+        cursor: _nextCursor!,
+        size: 50,
+      );
+      _cacheChatList.addAll(res.pages);
+      _hasNext = res.hasNext;
+      _nextCursor = res.nextCursor;
+
+      viewChatList.assignAll(
+        _cacheChatList.reversed.map(
+          (e) => ChatMessageViewModel.fromJsonChatMessageEntity(e),
+        ),
+      );
+    } finally {
+      _isLoadingMore = false;
     }
   }
 

--- a/lib/presentation/chat/screens/chat_room_screen.dart
+++ b/lib/presentation/chat/screens/chat_room_screen.dart
@@ -56,6 +56,7 @@ class ChatRoomScreen extends GetView<ChatRoomController> {
 
   Widget _chatList() => ListView.builder(
     controller: controller.scrollController,
+    reverse: true,
     itemBuilder: (context, index) {
       final chat = controller.viewChatList[index];
       if (chat.isMe) {

--- a/lib/presentation/chat/screens/chat_room_screen.dart
+++ b/lib/presentation/chat/screens/chat_room_screen.dart
@@ -55,6 +55,7 @@ class ChatRoomScreen extends GetView<ChatRoomController> {
   );
 
   Widget _chatList() => ListView.builder(
+    controller: controller.scrollController,
     itemBuilder: (context, index) {
       final chat = controller.viewChatList[index];
       if (chat.isMe) {


### PR DESCRIPTION
## 📌 개요

채팅 메시지 목록 조회 시 전체 메시지를 한 번에 불러오던 문제를 해결합니다. 커서 기반 페이지네이션을 적용하여 첫 페이지만 로드하고, 스크롤 상단 도달 시 이전 메시지를 추가 로드합니다.

---

## 🧩 작업 내용

- [x]  `_initLoadChatRoomMessages()` while 루프 제거 → 첫 페이지(size: 50)만 로드
- [x]  `loadMoreMessages()` 추가 — `_hasNext`, `_nextCursor` 기반 추가 로드
- [x]  `ScrollController` 컨트롤러에서 관리 및 스크롤 리스너 연결
- [x]  `ListView`에 `controller.scrollController` 연결

---

## 📎 참고 사항

- 스크롤이 하단 기준 200px 이내 도달 시 `loadMoreMessages()` 호출 (ListView가 최신 메시지 기준 역순이므로 상단 = 오래된 메시지)
- 중복 로드 방지를 위해 `_isLoadingMore` 플래그 사용

close: #223 