### PR TITLE
[BUG] 채팅 히스토리 isMe 판별

### DIFF
--- a/lib/core/utils/app_date_utils.dart
+++ b/lib/core/utils/app_date_utils.dart
@@ -1,4 +1,5 @@
 class AppDateUtils {
+  static final RegExp _nanoSecondsRegex = RegExp(r'(\.\d{6})\d+(Z|[+-].*)$');
   static String timeAgo(DateTime? dateTime) {
     if (dateTime == null) return "";
 
@@ -55,7 +56,7 @@ class AppDateUtils {
 
     // 소수점 이하 7자리 이상 잘라내기 (나노초 → 마이크로초)
     return withZ.replaceFirstMapped(
-      RegExp(r'(\.\d{6})\d+(Z|[+-].*)$'),
+      _nanoSecondsRegex,
       (m) => '${m.group(1)}${m.group(2)}',
     );
   }

--- a/lib/core/utils/app_date_utils.dart
+++ b/lib/core/utils/app_date_utils.dart
@@ -37,6 +37,10 @@ class AppDateUtils {
   ///
   /// 시간 파트(`T` 또는 공백)가 없는 날짜 전용 문자열(예: `"2024-01-15"`)은
   /// `DateTime.parse()`가 시간대 접미사를 지원하지 않으므로 그대로 반환한다.
+  ///
+  /// Dart의 [DateTime.parse]는 소수점 이하 최대 6자리(마이크로초)만 지원한다.
+  /// 서버가 나노초(9자리) 등 더 긴 소수점을 반환하면 파싱이 실패하므로
+  /// 소수점 7자리 이상은 잘라낸다.
   static String _withUtcSuffix(String s) {
     // 시간 파트가 없으면 Z 붙여도 FormatException 발생 → 그대로 반환
     final hasTimePart = s.contains('T') || s.contains(' ');
@@ -47,6 +51,12 @@ class AppDateUtils {
         s.endsWith('Z') ||
         s.contains('+') ||
         (s.length > 10 && s.substring(10).contains('-'));
-    return hasTimezone ? s : '${s}Z';
+    final withZ = hasTimezone ? s : '${s}Z';
+
+    // 소수점 이하 7자리 이상 잘라내기 (나노초 → 마이크로초)
+    return withZ.replaceFirstMapped(
+      RegExp(r'(\.\d{6})\d+(Z|[+-].*)$'),
+      (m) => '${m.group(1)}${m.group(2)}',
+    );
   }
 }

--- a/lib/data/models/chat/response/chat_message_model.dart
+++ b/lib/data/models/chat/response/chat_message_model.dart
@@ -21,7 +21,7 @@ class ChatMessageModel extends BaseModel {
     required this.createdAt,
   });
 
-  factory ChatMessageModel.fromJson(Map json) => ChatMessageModel(
+  factory ChatMessageModel.fromJson(Map<String, dynamic> json) => ChatMessageModel(
     messageId: (json["messageId"] as num).toInt(),
     roomId: json["roomId"] as String,
     senderPublicId: json["senderPublicId"] as String?,

--- a/lib/data/models/chat/response/chat_message_model.dart
+++ b/lib/data/models/chat/response/chat_message_model.dart
@@ -3,7 +3,9 @@ import 'package:ondo/data/models/base/response/base_model.dart';
 class ChatMessageModel extends BaseModel {
   final int messageId;
   final String roomId;
-  final int senderId;
+  final String? senderPublicId;
+  final String? senderDisplayName;
+  final String? senderProfileImageKey;
   final String messageType;
   final String content;
   final String createdAt;
@@ -11,26 +13,32 @@ class ChatMessageModel extends BaseModel {
   ChatMessageModel({
     required this.messageId,
     required this.roomId,
-    required this.senderId,
+    required this.senderPublicId,
+    required this.senderDisplayName,
+    required this.senderProfileImageKey,
     required this.messageType,
     required this.content,
     required this.createdAt,
   });
 
   factory ChatMessageModel.fromJson(Map json) => ChatMessageModel(
-    messageId: json["messageId"],
-    roomId: json["roomId"],
-    senderId: json["senderId"],
-    messageType: json["messageType"],
-    content: json["content"],
-    createdAt: json["createdAt"],
+    messageId: (json["messageId"] as num).toInt(),
+    roomId: json["roomId"] as String,
+    senderPublicId: json["senderPublicId"] as String?,
+    senderDisplayName: json["senderDisplayName"] as String?,
+    senderProfileImageKey: json["senderProfileImageKey"] as String?,
+    messageType: json["messageType"] as String? ?? 'TEXT',
+    content: json["content"] as String? ?? '',
+    createdAt: json["createdAt"] as String? ?? '',
   );
 
   @override
   Map<String, dynamic> toJson() => {
     "messageId": messageId,
     "roomId": roomId,
-    "senderId": senderId,
+    "senderPublicId": senderPublicId,
+    "senderDisplayName": senderDisplayName,
+    "senderProfileImageKey": senderProfileImageKey,
     "messageType": messageType,
     "content": content,
     "createdAt": createdAt,

--- a/lib/data/network/clients/auth_client.dart
+++ b/lib/data/network/clients/auth_client.dart
@@ -1,6 +1,7 @@
 import 'dart:developer';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart';
+import 'package:ondo/core/utils/app_date_utils.dart';
 import 'package:ondo/data/datasource/auth/auth_remote_datasource.dart';
 import 'package:ondo/data/datasource/base/auth_local_datasource.dart';
 import 'package:ondo/data/models/auth/response/sign_in_response_model.dart';
@@ -85,7 +86,7 @@ class AuthClient extends BaseClient {
     final expirationStr = await localDatasource.getAccessTokenExpiration();
     if (expirationStr == null) return token;
 
-    final expiration = DateTime.tryParse(expirationStr);
+    final expiration = AppDateUtils.tryParseUtc(expirationStr);
     if (expiration == null) return token;
 
     // 유효기간이 남아있으면 그대로 사용
@@ -109,7 +110,7 @@ class AuthClient extends BaseClient {
     // refreshToken 만료 여부 사전 확인
     final refreshExpirationStr = await localDatasource.getRefreshTokenExpiration();
     if (refreshExpirationStr != null) {
-      final refreshExpiration = DateTime.tryParse(refreshExpirationStr);
+      final refreshExpiration = AppDateUtils.tryParseUtc(refreshExpirationStr);
       if (refreshExpiration != null && DateTime.now().isAfter(refreshExpiration)) {
         log("RefreshToken 만료 → 토큰 삭제 후 로그인 화면 이동");
         await localDatasource.deleteAll();

--- a/lib/domain/entities/chat/chat_message_entity.dart
+++ b/lib/domain/entities/chat/chat_message_entity.dart
@@ -4,7 +4,9 @@ import 'package:ondo/data/models/chat/response/chat_message_model.dart';
 class ChatMessageEntity {
   final int messageId;
   final String roomId;
-  final int senderId;
+  final String? senderPublicId;
+  final String? senderDisplayName;
+  final String? senderProfileImageKey;
   final String messageType;
   final String content;
   final DateTime createdAt;
@@ -12,7 +14,9 @@ class ChatMessageEntity {
   ChatMessageEntity({
     required this.messageId,
     required this.roomId,
-    required this.senderId,
+    required this.senderPublicId,
+    required this.senderDisplayName,
+    required this.senderProfileImageKey,
     required this.messageType,
     required this.content,
     required this.createdAt,
@@ -22,7 +26,9 @@ class ChatMessageEntity {
       ChatMessageEntity(
         messageId: model.messageId,
         roomId: model.roomId,
-        senderId: model.senderId,
+        senderPublicId: model.senderPublicId,
+        senderDisplayName: model.senderDisplayName,
+        senderProfileImageKey: model.senderProfileImageKey,
         messageType: model.messageType,
         content: model.content,
         createdAt: AppDateUtils.parseUtc(model.createdAt),

--- a/lib/presentation/auth/login/controllers/splash_controller.dart
+++ b/lib/presentation/auth/login/controllers/splash_controller.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/animation.dart';
 import 'package:get/get.dart';
+import 'package:ondo/core/utils/app_date_utils.dart';
 import 'package:ondo/data/datasource/base/auth_local_datasource.dart';
 
 class SplashController extends GetxController
@@ -45,7 +46,7 @@ class SplashController extends GetxController
     final expirationStr = await localDatasource.getAccessTokenExpiration();
     if (expirationStr == null) return false;
 
-    final expiration = DateTime.tryParse(expirationStr);
+    final expiration = AppDateUtils.tryParseUtc(expirationStr);
     if (expiration == null) return false;
 
     // refreshToken도 확인
@@ -56,7 +57,7 @@ class SplashController extends GetxController
     await localDatasource.getRefreshTokenExpiration();
     if (refreshExpirationStr == null) return false;
 
-    final refreshExpiration = DateTime.tryParse(refreshExpirationStr);
+    final refreshExpiration = AppDateUtils.tryParseUtc(refreshExpirationStr);
     if (refreshExpiration == null) return false;
 
     // refreshToken이 유효하면 로그인 상태로 간주

--- a/lib/presentation/chat/controllers/chat_room_controller.dart
+++ b/lib/presentation/chat/controllers/chat_room_controller.dart
@@ -402,7 +402,7 @@ class ChatRoomController extends GetxController with WidgetsBindingObserver {
         }
       } else {
         // 상대방 메시지 → 리스트 앞에 삽입
-        final viewModel = ChatMessageViewModel.fromJson(json);
+        final viewModel = ChatMessageViewModel.fromJson(json, myPublicId: _myPublicId);
         viewChatList.insert(0, viewModel);
         log('[ChatRoom] 메시지 수신: $content');
 
@@ -466,8 +466,9 @@ class ChatRoomController extends GetxController with WidgetsBindingObserver {
       _hasNext = res.hasNext;
       _nextCursor = res.nextCursor;
 
-      viewChatList.assignAll(
-        _cacheChatList.map(
+      // assignAll 대신 addAll로 이전 메시지만 추가 — 실시간 수신 메시지 유실 방지
+      viewChatList.addAll(
+        res.pages.map(
           (e) => ChatMessageViewModel.fromJsonChatMessageEntity(
             e,
             myPublicId: _myPublicId,

--- a/lib/presentation/chat/controllers/chat_room_controller.dart
+++ b/lib/presentation/chat/controllers/chat_room_controller.dart
@@ -441,7 +441,10 @@ class ChatRoomController extends GetxController with WidgetsBindingObserver {
     if (_cacheChatList.isNotEmpty) {
       viewChatList.assignAll(
         _cacheChatList.map(
-          (e) => ChatMessageViewModel.fromJsonChatMessageEntity(e),
+          (e) => ChatMessageViewModel.fromJsonChatMessageEntity(
+            e,
+            myPublicId: _myPublicId,
+          ),
         ),
       );
       lastMessageId = _cacheChatList.first.messageId;
@@ -465,7 +468,10 @@ class ChatRoomController extends GetxController with WidgetsBindingObserver {
 
       viewChatList.assignAll(
         _cacheChatList.map(
-          (e) => ChatMessageViewModel.fromJsonChatMessageEntity(e),
+          (e) => ChatMessageViewModel.fromJsonChatMessageEntity(
+            e,
+            myPublicId: _myPublicId,
+          ),
         ),
       );
     } finally {

--- a/lib/presentation/chat/view_models/chat_message_view_model.dart
+++ b/lib/presentation/chat/view_models/chat_message_view_model.dart
@@ -19,26 +19,25 @@ class ChatMessageViewModel {
   });
 
   /// HTTP 히스토리 메시지 → ViewModel
-  ///
-  /// TODO: senderId(int)와 myPublicId(String UUID)는 타입이 달라 직접 비교 불가.
-  ///       서버가 senderPublicId(String)를 응답에 추가하거나, myUserId(int)를 별도
-  ///       저장하는 후속 작업(#200 이후) 시 isMe 처리 완성 예정.
   factory ChatMessageViewModel.fromJsonChatMessageEntity(
-    ChatMessageEntity entity,
-  ) => ChatMessageViewModel(
+    ChatMessageEntity entity, {
+    String? myPublicId,
+  }) => ChatMessageViewModel(
     messageId: entity.messageId,
     messageType: entity.messageType,
     content: entity.content,
     createdAt: entity.createdAt,
-    isMe: false,
-    profileImageKey: null, //TODO : senderId로 프로필 이미지 조회 예정
+    isMe: myPublicId != null &&
+        entity.senderPublicId != null &&
+        entity.senderPublicId == myPublicId,
+    profileImageKey: null, // TODO: senderPublicId로 프로필 이미지 조회 예정
   );
 
   /// WebSocket 실시간 수신 메시지 → ViewModel
   ///
   /// 서버 payload:
   /// ```json
-  /// { "messageId", "roomId", "senderId", "messageType", "content", "createdAt" }
+  /// { "messageId", "roomId", "senderId", "senderPublicId", "messageType", "content", "createdAt" }
   /// ```
   /// 내가 보낸 메시지는 ChatRoomController의 echo 감지(_pendingSentContents)로
   /// 처리되므로 이 factory는 상대방 메시지에만 호출된다 → isMe: false 고정.
@@ -51,6 +50,6 @@ class ChatMessageViewModel {
             AppDateUtils.tryParseUtc(json['createdAt'] as String?) ??
             DateTime.now(),
         isMe: false,
-        profileImageKey: null, // TODO: senderId로 프로필 이미지 조회 예정
+        profileImageKey: null, // TODO: senderPublicId로 프로필 이미지 조회 예정
       );
 }

--- a/lib/presentation/chat/view_models/chat_message_view_model.dart
+++ b/lib/presentation/chat/view_models/chat_message_view_model.dart
@@ -37,11 +37,13 @@ class ChatMessageViewModel {
   ///
   /// 서버 payload:
   /// ```json
-  /// { "messageId", "roomId", "senderId", "senderPublicId", "messageType", "content", "createdAt" }
+  /// { "messageId", "roomId", "senderPublicId", "messageType", "content", "createdAt" }
   /// ```
-  /// 내가 보낸 메시지는 ChatRoomController의 echo 감지(_pendingSentContents)로
-  /// 처리되므로 이 factory는 상대방 메시지에만 호출된다 → isMe: false 고정.
-  factory ChatMessageViewModel.fromJson(Map<String, dynamic> json) =>
+  /// [myPublicId]를 전달하면 다중 기기 로그인 환경에서도 본인 메시지를 올바르게 판별한다.
+  factory ChatMessageViewModel.fromJson(
+    Map<String, dynamic> json, {
+    String? myPublicId,
+  }) =>
       ChatMessageViewModel(
         messageId: (json['messageId'] as num?)?.toInt(),
         messageType: json['messageType'] as String? ?? 'TEXT',
@@ -49,7 +51,9 @@ class ChatMessageViewModel {
         createdAt:
             AppDateUtils.tryParseUtc(json['createdAt'] as String?) ??
             DateTime.now(),
-        isMe: false,
+        isMe: myPublicId != null &&
+            json['senderPublicId'] != null &&
+            json['senderPublicId'] == myPublicId,
         profileImageKey: null, // TODO: senderPublicId로 프로필 이미지 조회 예정
       );
 }


### PR DESCRIPTION
## 📌 개요

서버 API 변경(senderId 제거, senderPublicId/senderDisplayName/senderProfileImageKey 추가)에 맞춰 채팅 메시지 모델을 업데이트하고, UTC 타임스탬프 파싱 버그 및 채팅 히스토리 isMe 판별 오류를 수정합니다.

---

## 🧩 작업 내용

- [x] `AppDateUtils`에 `parseUtc` / `tryParseUtc` 헬퍼 추가 및 나노초 소수점 방어 처리
- [x] `AuthClient`, `SplashController` 토큰 만료 시간 UTC 파싱 수정
- [x] `ChatMessageModel` / `ChatMessageEntity` sender 필드 업데이트 (`senderId` 제거, `senderPublicId` 등 추가)
- [x] `ChatRoomController`에서 `fromJsonChatMessageEntity` 호출 시 `myPublicId` 전달
- [x] `ChatMessageViewModel`에서 `senderPublicId` 기반 `isMe` 판별 적용

---

## 📎 참고 사항

- `GET /chat/rooms/{chatRoomPublicId}/messages` 응답 변경사항 반영
- Dart의 `DateTime.parse`는 소수점 이하 최대 6자리만 지원 — 서버가 나노초(9자리)를 반환할 경우 파싱 실패 방지 처리 포함

close #202 